### PR TITLE
fix: resolve full message payload from Redis JSON

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.5
 require (
 	charm.land/bubbletea/v2 v2.0.1
 	charm.land/lipgloss/v2 v2.0.0
+	github.com/redis/go-redis/v9 v9.7.0
 	github.com/stuttgart-things/homerun-library/v2 v2.0.1-0.20260307163657-17be19573fe0
 	github.com/stuttgart-things/redisqueue v0.0.0-20230628084515-1d31f7874df7
 )
@@ -160,7 +161,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pterm/pterm v0.12.83 // indirect
-	github.com/redis/go-redis/v9 v9.7.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/internal/catcher/catcher.go
+++ b/internal/catcher/catcher.go
@@ -1,11 +1,13 @@
 package catcher
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 
+	"github.com/redis/go-redis/v9"
 	homerun "github.com/stuttgart-things/homerun-library/v2"
 	"github.com/stuttgart-things/redisqueue"
 )
@@ -17,10 +19,11 @@ type Catcher interface {
 	Errors() <-chan error
 }
 
-// RedisCatcher consumes messages from Redis Streams and logs them.
+// RedisCatcher consumes messages from Redis Streams and resolves full payloads from Redis JSON.
 type RedisCatcher struct {
-	consumer *redisqueue.Consumer
-	stream   string
+	consumer    *redisqueue.Consumer
+	redisClient *redis.Client
+	stream      string
 }
 
 // NewRedisCatcher creates a consumer connected to the given Redis stream.
@@ -33,9 +36,9 @@ func NewRedisCatcher(rc homerun.RedisConfig, groupName, consumerName string) (*R
 	addr := fmt.Sprintf("%s:%s", rc.Addr, rc.Port)
 
 	consumer, err := redisqueue.NewConsumerWithOptions(&redisqueue.ConsumerOptions{
-		Name:       consumerName,
-		GroupName:  groupName,
-		BufferSize: 100,
+		Name:        consumerName,
+		GroupName:   groupName,
+		BufferSize:  100,
 		Concurrency: 10,
 		RedisOptions: &redisqueue.RedisOptions{
 			Addr:     addr,
@@ -46,9 +49,15 @@ func NewRedisCatcher(rc homerun.RedisConfig, groupName, consumerName string) (*R
 		return nil, fmt.Errorf("failed to create redis consumer: %w", err)
 	}
 
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:     addr,
+		Password: rc.Password,
+	})
+
 	c := &RedisCatcher{
-		consumer: consumer,
-		stream:   rc.Stream,
+		consumer:    consumer,
+		redisClient: redisClient,
+		stream:      rc.Stream,
 	}
 
 	consumer.Register(rc.Stream, c.handleMessage)
@@ -61,9 +70,12 @@ func (c *RedisCatcher) Run() {
 	c.consumer.Run()
 }
 
-// Shutdown gracefully stops the consumer.
+// Shutdown gracefully stops the consumer and closes the Redis client.
 func (c *RedisCatcher) Shutdown() {
 	c.consumer.Shutdown()
+	if c.redisClient != nil {
+		c.redisClient.Close()
+	}
 }
 
 // Errors returns the consumer's error channel.
@@ -73,27 +85,65 @@ func (c *RedisCatcher) Errors() <-chan error {
 
 // handleMessage is called for each message received from the stream.
 func (c *RedisCatcher) handleMessage(msg *redisqueue.Message) error {
-	// Log the raw stream message
 	slog.Info("message caught",
 		"stream", msg.Stream,
 		"id", msg.ID,
 	)
 
-	// The stream entry contains a messageID field referencing the Redis JSON object
-	if messageID, ok := msg.Values["messageID"]; ok {
-		slog.Info("message reference",
-			"messageID", messageID,
-			"stream_id", msg.ID,
-		)
+	messageID, ok := msg.Values["messageID"]
+	if !ok {
+		slog.Warn("stream entry missing messageID field", "id", msg.ID)
+		return nil
 	}
 
-	// Log all values from the stream entry
-	valuesJSON, err := json.Marshal(msg.Values)
-	if err != nil {
-		slog.Warn("failed to marshal message values", "error", err)
-	} else {
-		slog.Info("message values", "data", string(valuesJSON))
+	messageIDStr, ok := messageID.(string)
+	if !ok {
+		slog.Warn("messageID is not a string", "id", msg.ID, "messageID", messageID)
+		return nil
 	}
+
+	slog.Info("message reference",
+		"messageID", messageIDStr,
+		"stream_id", msg.ID,
+	)
+
+	// Resolve full message payload from Redis JSON
+	payload, err := c.resolveMessage(messageIDStr)
+	if err != nil {
+		slog.Warn("failed to resolve message from Redis JSON",
+			"messageID", messageIDStr,
+			"error", err,
+		)
+		return nil
+	}
+
+	slog.Info("message payload",
+		"messageID", messageIDStr,
+		"title", payload.Title,
+		"message", payload.Message,
+		"severity", payload.Severity,
+		"author", payload.Author,
+		"system", payload.System,
+		"timestamp", payload.Timestamp,
+		"tags", payload.Tags,
+	)
 
 	return nil
+}
+
+// resolveMessage fetches the full message payload from Redis JSON using JSON.GET.
+func (c *RedisCatcher) resolveMessage(messageID string) (*homerun.Message, error) {
+	ctx := context.Background()
+
+	result, err := c.redisClient.Do(ctx, "JSON.GET", messageID, ".").Text()
+	if err != nil {
+		return nil, fmt.Errorf("JSON.GET %s: %w", messageID, err)
+	}
+
+	var msg homerun.Message
+	if err := json.Unmarshal([]byte(result), &msg); err != nil {
+		return nil, fmt.Errorf("unmarshal message: %w", err)
+	}
+
+	return &msg, nil
 }


### PR DESCRIPTION
## Summary

- After catching a message from the Redis Stream, use `JSON.GET` to fetch the full `homerun.Message` payload from Redis JSON using the `messageID` reference
- Log all message fields (title, message, severity, author, system, timestamp, tags)
- Add a dedicated `redis.Client` to `RedisCatcher` for JSON lookups (the redisqueue consumer doesn't expose its client)
- Gracefully handle missing/malformed JSON keys

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Deploy to cluster and send test messages via omni-pitcher — verify full payload appears in logs

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)