### PR TITLE
feat: MessageStore, log mode, FileCatcher, and mode selection

### DIFF
--- a/internal/catcher/catcher.go
+++ b/internal/catcher/catcher.go
@@ -6,11 +6,16 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 	homerun "github.com/stuttgart-things/homerun-library/v2"
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/models"
 	"github.com/stuttgart-things/redisqueue"
 )
+
+// MessageHandler processes a caught message.
+type MessageHandler func(msg models.CaughtMessage)
 
 // Catcher defines the interface for message consumption backends.
 type Catcher interface {
@@ -24,10 +29,11 @@ type RedisCatcher struct {
 	consumer    *redisqueue.Consumer
 	redisClient *redis.Client
 	stream      string
+	handlers    []MessageHandler
 }
 
 // NewRedisCatcher creates a consumer connected to the given Redis stream.
-func NewRedisCatcher(rc homerun.RedisConfig, groupName, consumerName string) (*RedisCatcher, error) {
+func NewRedisCatcher(rc homerun.RedisConfig, groupName, consumerName string, handlers ...MessageHandler) (*RedisCatcher, error) {
 	if consumerName == "" {
 		hostname, _ := os.Hostname()
 		consumerName = hostname
@@ -58,6 +64,7 @@ func NewRedisCatcher(rc homerun.RedisConfig, groupName, consumerName string) (*R
 		consumer:    consumer,
 		redisClient: redisClient,
 		stream:      rc.Stream,
+		handlers:    handlers,
 	}
 
 	consumer.Register(rc.Stream, c.handleMessage)
@@ -85,11 +92,6 @@ func (c *RedisCatcher) Errors() <-chan error {
 
 // handleMessage is called for each message received from the stream.
 func (c *RedisCatcher) handleMessage(msg *redisqueue.Message) error {
-	slog.Info("message caught",
-		"stream", msg.Stream,
-		"id", msg.ID,
-	)
-
 	messageID, ok := msg.Values["messageID"]
 	if !ok {
 		slog.Warn("stream entry missing messageID field", "id", msg.ID)
@@ -102,12 +104,6 @@ func (c *RedisCatcher) handleMessage(msg *redisqueue.Message) error {
 		return nil
 	}
 
-	slog.Info("message reference",
-		"messageID", messageIDStr,
-		"stream_id", msg.ID,
-	)
-
-	// Resolve full message payload from Redis JSON
 	payload, err := c.resolveMessage(messageIDStr)
 	if err != nil {
 		slog.Warn("failed to resolve message from Redis JSON",
@@ -117,16 +113,16 @@ func (c *RedisCatcher) handleMessage(msg *redisqueue.Message) error {
 		return nil
 	}
 
-	slog.Info("message payload",
-		"messageID", messageIDStr,
-		"title", payload.Title,
-		"message", payload.Message,
-		"severity", payload.Severity,
-		"author", payload.Author,
-		"system", payload.System,
-		"timestamp", payload.Timestamp,
-		"tags", payload.Tags,
-	)
+	caught := models.CaughtMessage{
+		Message:  *payload,
+		ObjectID: messageIDStr,
+		StreamID: msg.ID,
+		CaughtAt: time.Now(),
+	}
+
+	for _, h := range c.handlers {
+		h(caught)
+	}
 
 	return nil
 }

--- a/internal/catcher/file.go
+++ b/internal/catcher/file.go
@@ -1,0 +1,107 @@
+package catcher
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	homerun "github.com/stuttgart-things/homerun-library/v2"
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/models"
+)
+
+// FileCatcher reads messages from a JSON file and replays them.
+type FileCatcher struct {
+	path     string
+	interval time.Duration
+	handlers []MessageHandler
+	quit     chan struct{}
+	done     chan struct{}
+	once     sync.Once
+}
+
+// NewFileCatcher creates a FileCatcher that replays messages from a JSON file.
+func NewFileCatcher(path string, interval time.Duration, handlers ...MessageHandler) *FileCatcher {
+	if interval <= 0 {
+		interval = time.Second
+	}
+	return &FileCatcher{
+		path:     path,
+		interval: interval,
+		handlers: handlers,
+		quit:     make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+}
+
+// Run reads messages from the file and dispatches them to handlers. Blocks until Shutdown.
+func (f *FileCatcher) Run() {
+	defer close(f.done)
+
+	messages, err := f.loadMessages()
+	if err != nil {
+		slog.Error("failed to load messages from file", "path", f.path, "error", err)
+		return
+	}
+
+	slog.Info("file catcher loaded messages", "count", len(messages), "path", f.path)
+
+	for i, msg := range messages {
+		select {
+		case <-f.quit:
+			return
+		default:
+		}
+
+		caught := models.CaughtMessage{
+			Message:  msg,
+			ObjectID: fmt.Sprintf("file-%d-%s", i, msg.System),
+			StreamID: "file",
+			CaughtAt: time.Now(),
+		}
+
+		for _, h := range f.handlers {
+			h(caught)
+		}
+
+		if i < len(messages)-1 {
+			select {
+			case <-f.quit:
+				return
+			case <-time.After(f.interval):
+			}
+		}
+	}
+
+	// Keep running until shutdown
+	<-f.quit
+}
+
+// Shutdown stops the file catcher.
+func (f *FileCatcher) Shutdown() {
+	f.once.Do(func() {
+		close(f.quit)
+	})
+	<-f.done
+}
+
+// Errors returns a nil channel (FileCatcher doesn't produce errors this way).
+func (f *FileCatcher) Errors() <-chan error {
+	return nil
+}
+
+func (f *FileCatcher) loadMessages() ([]homerun.Message, error) {
+	data, err := os.ReadFile(f.path)
+	if err != nil {
+		return nil, fmt.Errorf("read file: %w", err)
+	}
+
+	var messages []homerun.Message
+	if err := json.Unmarshal(data, &messages); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+
+	return messages, nil
+}

--- a/internal/catcher/handlers.go
+++ b/internal/catcher/handlers.go
@@ -1,0 +1,47 @@
+package catcher
+
+import (
+	"log/slog"
+
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/models"
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/store"
+)
+
+// LogHandler returns a MessageHandler that logs messages with severity-aware levels.
+func LogHandler() MessageHandler {
+	return func(msg models.CaughtMessage) {
+		level := severityToLevel(msg.Severity)
+
+		slog.Log(nil, level, "message caught",
+			"objectId", msg.ObjectID,
+			"streamId", msg.StreamID,
+			"title", msg.Title,
+			"message", msg.Message.Message,
+			"severity", msg.Severity,
+			"author", msg.Author,
+			"system", msg.System,
+			"timestamp", msg.Timestamp,
+			"tags", msg.Tags,
+		)
+	}
+}
+
+// StoreHandler returns a MessageHandler that stores messages in the given store.
+func StoreHandler(s *store.MessageStore) MessageHandler {
+	return func(msg models.CaughtMessage) {
+		s.Add(msg)
+	}
+}
+
+func severityToLevel(severity string) slog.Level {
+	switch severity {
+	case "error":
+		return slog.LevelError
+	case "warning":
+		return slog.LevelWarn
+	case "debug":
+		return slog.LevelDebug
+	default: // info, success, etc.
+		return slog.LevelInfo
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,0 +1,15 @@
+package models
+
+import (
+	"time"
+
+	homerun "github.com/stuttgart-things/homerun-library/v2"
+)
+
+// CaughtMessage wraps a homerun.Message with stream metadata.
+type CaughtMessage struct {
+	homerun.Message
+	ObjectID string    `json:"objectId"`
+	StreamID string    `json:"streamId"`
+	CaughtAt time.Time `json:"caughtAt"`
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,0 +1,177 @@
+package store
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/models"
+)
+
+// SortField defines which field to sort by.
+type SortField int
+
+const (
+	SortByTimestamp SortField = iota
+	SortBySeverity
+	SortBySystem
+	SortByAuthor
+	SortByTitle
+)
+
+// SortDirection defines sort order.
+type SortDirection int
+
+const (
+	SortAsc SortDirection = iota
+	SortDesc
+)
+
+// ListOptions controls pagination and sorting.
+type ListOptions struct {
+	Offset    int
+	Limit     int
+	SortBy    SortField
+	SortDir   SortDirection
+}
+
+// MessageStore holds caught messages in memory.
+type MessageStore struct {
+	mu       sync.RWMutex
+	messages []models.CaughtMessage
+	byID     map[string]int // objectID -> index
+	maxSize  int
+}
+
+// New creates a MessageStore with the given capacity.
+func New(maxSize int) *MessageStore {
+	if maxSize <= 0 {
+		maxSize = 10000
+	}
+	return &MessageStore{
+		messages: make([]models.CaughtMessage, 0, maxSize),
+		byID:     make(map[string]int, maxSize),
+		maxSize:  maxSize,
+	}
+}
+
+// Add appends a message, evicting the oldest if at capacity.
+func (s *MessageStore) Add(msg models.CaughtMessage) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.messages) >= s.maxSize {
+		// evict oldest
+		old := s.messages[0]
+		delete(s.byID, old.ObjectID)
+		s.messages = s.messages[1:]
+		// rebuild index
+		for i, m := range s.messages {
+			s.byID[m.ObjectID] = i
+		}
+	}
+
+	s.byID[msg.ObjectID] = len(s.messages)
+	s.messages = append(s.messages, msg)
+}
+
+// List returns messages according to the given options.
+func (s *MessageStore) List(opts ListOptions) []models.CaughtMessage {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sorted := s.sorted(opts.SortBy, opts.SortDir)
+
+	if opts.Offset >= len(sorted) {
+		return nil
+	}
+
+	end := opts.Offset + opts.Limit
+	if opts.Limit <= 0 || end > len(sorted) {
+		end = len(sorted)
+	}
+
+	result := make([]models.CaughtMessage, end-opts.Offset)
+	copy(result, sorted[opts.Offset:end])
+	return result
+}
+
+// Search returns messages where any field contains the query string (case-insensitive).
+func (s *MessageStore) Search(query string) []models.CaughtMessage {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	q := strings.ToLower(query)
+	var results []models.CaughtMessage
+
+	for _, m := range s.messages {
+		if matchesQuery(m, q) {
+			results = append(results, m)
+		}
+	}
+	return results
+}
+
+// Get returns a message by objectID.
+func (s *MessageStore) Get(id string) (models.CaughtMessage, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	idx, ok := s.byID[id]
+	if !ok {
+		return models.CaughtMessage{}, false
+	}
+	return s.messages[idx], true
+}
+
+// Count returns the number of stored messages.
+func (s *MessageStore) Count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.messages)
+}
+
+func matchesQuery(m models.CaughtMessage, q string) bool {
+	fields := []string{
+		m.Title, m.Message.Message, m.Severity, m.Author,
+		m.System, m.Tags, m.ObjectID, m.AssigneeName,
+	}
+	for _, f := range fields {
+		if strings.Contains(strings.ToLower(f), q) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *MessageStore) sorted(by SortField, dir SortDirection) []models.CaughtMessage {
+	cp := make([]models.CaughtMessage, len(s.messages))
+	copy(cp, s.messages)
+
+	less := func(i, j int) bool {
+		var a, b string
+		switch by {
+		case SortBySeverity:
+			a, b = cp[i].Severity, cp[j].Severity
+		case SortBySystem:
+			a, b = cp[i].System, cp[j].System
+		case SortByAuthor:
+			a, b = cp[i].Author, cp[j].Author
+		case SortByTitle:
+			a, b = cp[i].Title, cp[j].Title
+		default: // SortByTimestamp
+			a, b = cp[i].CaughtAt.String(), cp[j].CaughtAt.String()
+		}
+		if dir == SortDesc {
+			return a > b
+		}
+		return a < b
+	}
+
+	// simple insertion sort (fine for bounded store)
+	for i := 1; i < len(cp); i++ {
+		for j := i; j > 0 && less(j, j-1); j-- {
+			cp[j], cp[j-1] = cp[j-1], cp[j]
+		}
+	}
+	return cp
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,127 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	homerun "github.com/stuttgart-things/homerun-library/v2"
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/models"
+)
+
+func newMsg(id, title, severity, system string) models.CaughtMessage {
+	return models.CaughtMessage{
+		Message: homerun.Message{
+			Title:    title,
+			Severity: severity,
+			System:   system,
+			Author:   "test",
+		},
+		ObjectID: id,
+		StreamID: "messages",
+		CaughtAt: time.Now(),
+	}
+}
+
+func TestAddAndCount(t *testing.T) {
+	s := New(100)
+	s.Add(newMsg("1", "first", "info", "ci"))
+	s.Add(newMsg("2", "second", "error", "ci"))
+
+	if s.Count() != 2 {
+		t.Fatalf("expected 2, got %d", s.Count())
+	}
+}
+
+func TestGet(t *testing.T) {
+	s := New(100)
+	s.Add(newMsg("abc", "test msg", "info", "ci"))
+
+	m, ok := s.Get("abc")
+	if !ok {
+		t.Fatal("expected to find message")
+	}
+	if m.Title != "test msg" {
+		t.Fatalf("expected 'test msg', got %q", m.Title)
+	}
+
+	_, ok = s.Get("nonexistent")
+	if ok {
+		t.Fatal("expected not found")
+	}
+}
+
+func TestEviction(t *testing.T) {
+	s := New(3)
+	s.Add(newMsg("1", "first", "info", "a"))
+	s.Add(newMsg("2", "second", "info", "b"))
+	s.Add(newMsg("3", "third", "info", "c"))
+	s.Add(newMsg("4", "fourth", "info", "d"))
+
+	if s.Count() != 3 {
+		t.Fatalf("expected 3 after eviction, got %d", s.Count())
+	}
+
+	_, ok := s.Get("1")
+	if ok {
+		t.Fatal("oldest message should have been evicted")
+	}
+
+	m, ok := s.Get("4")
+	if !ok || m.Title != "fourth" {
+		t.Fatal("newest message should exist")
+	}
+}
+
+func TestSearch(t *testing.T) {
+	s := New(100)
+	s.Add(newMsg("1", "Deploy complete", "success", "argocd"))
+	s.Add(newMsg("2", "Build failed", "error", "jenkins"))
+	s.Add(newMsg("3", "Config update", "info", "argocd"))
+
+	results := s.Search("argocd")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	results = s.Search("FAILED")
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for case-insensitive search, got %d", len(results))
+	}
+}
+
+func TestList(t *testing.T) {
+	s := New(100)
+	for i := 0; i < 10; i++ {
+		s.Add(newMsg(fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i), "info", "ci"))
+	}
+
+	// pagination
+	page := s.List(ListOptions{Offset: 2, Limit: 3})
+	if len(page) != 3 {
+		t.Fatalf("expected 3, got %d", len(page))
+	}
+
+	// no limit
+	all := s.List(ListOptions{})
+	if len(all) != 10 {
+		t.Fatalf("expected 10, got %d", len(all))
+	}
+}
+
+func TestListSorted(t *testing.T) {
+	s := New(100)
+	s.Add(newMsg("1", "Zebra", "info", "ci"))
+	s.Add(newMsg("2", "Alpha", "error", "ci"))
+	s.Add(newMsg("3", "Middle", "warning", "ci"))
+
+	result := s.List(ListOptions{SortBy: SortByTitle, SortDir: SortAsc})
+	if result[0].Title != "Alpha" || result[2].Title != "Zebra" {
+		t.Fatalf("expected sorted asc by title, got %v", []string{result[0].Title, result[1].Title, result[2].Title})
+	}
+
+	result = s.List(ListOptions{SortBy: SortByTitle, SortDir: SortDesc})
+	if result[0].Title != "Zebra" || result[2].Title != "Alpha" {
+		t.Fatalf("expected sorted desc by title")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,11 +5,14 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/stuttgart-things/homerun2-core-catcher/internal/banner"
 	"github.com/stuttgart-things/homerun2-core-catcher/internal/catcher"
 	"github.com/stuttgart-things/homerun2-core-catcher/internal/config"
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/store"
 
 	homerun "github.com/stuttgart-things/homerun-library/v2"
 )
@@ -32,33 +35,75 @@ func main() {
 		"go", runtime.Version(),
 	)
 
-	redisConfig := config.LoadRedisConfig()
-	consumerGroup := homerun.GetEnv("CONSUMER_GROUP", "homerun2-core-catcher")
-	consumerName := homerun.GetEnv("CONSUMER_NAME", "")
+	mode := homerun.GetEnv("CATCHER_MODE", "log")
+	backend := homerun.GetEnv("CATCHER_BACKEND", "redis")
 
-	c, err := catcher.NewRedisCatcher(redisConfig, consumerGroup, consumerName)
-	if err != nil {
-		slog.Error("failed to create catcher", "error", err)
-		os.Exit(1)
+	// Build message handlers based on mode
+	var handlers []catcher.MessageHandler
+
+	// Log handler is always active
+	handlers = append(handlers, catcher.LogHandler())
+
+	// Store handler for modes that need in-memory storage (cli, web)
+	var msgStore *store.MessageStore
+	if mode == "cli" || mode == "web" {
+		maxMessages, _ := strconv.Atoi(homerun.GetEnv("MAX_MESSAGES", "10000"))
+		msgStore = store.New(maxMessages)
+		handlers = append(handlers, catcher.StoreHandler(msgStore))
+		_ = msgStore // will be used by TUI/web in future
 	}
 
-	slog.Info("catcher configured",
-		"redis_addr", redisConfig.Addr,
-		"redis_port", redisConfig.Port,
-		"stream", redisConfig.Stream,
-		"consumer_group", consumerGroup,
-	)
+	// Create catcher backend
+	var c catcher.Catcher
+
+	switch backend {
+	case "file":
+		filePath := homerun.GetEnv("CATCHER_FILE_PATH", "messages.json")
+		intervalStr := homerun.GetEnv("CATCHER_FILE_INTERVAL", "1s")
+		interval, err := time.ParseDuration(intervalStr)
+		if err != nil {
+			interval = time.Second
+		}
+		c = catcher.NewFileCatcher(filePath, interval, handlers...)
+		slog.Info("catcher configured",
+			"backend", "file",
+			"path", filePath,
+			"interval", interval,
+			"mode", mode,
+		)
+	default:
+		redisConfig := config.LoadRedisConfig()
+		consumerGroup := homerun.GetEnv("CONSUMER_GROUP", "homerun2-core-catcher")
+		consumerName := homerun.GetEnv("CONSUMER_NAME", "")
+
+		var err error
+		c, err = catcher.NewRedisCatcher(redisConfig, consumerGroup, consumerName, handlers...)
+		if err != nil {
+			slog.Error("failed to create catcher", "error", err)
+			os.Exit(1)
+		}
+		slog.Info("catcher configured",
+			"backend", "redis",
+			"redis_addr", redisConfig.Addr,
+			"redis_port", redisConfig.Port,
+			"stream", redisConfig.Stream,
+			"consumer_group", consumerGroup,
+			"mode", mode,
+		)
+	}
 
 	// Handle shutdown signals
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
-	// Run consumer in goroutine, collect errors
-	go func() {
-		for err := range c.Errors() {
-			slog.Error("consumer error", "error", err)
-		}
-	}()
+	// Collect errors
+	if errCh := c.Errors(); errCh != nil {
+		go func() {
+			for err := range errCh {
+				slog.Error("consumer error", "error", err)
+			}
+		}()
+	}
 
 	go func() {
 		<-quit


### PR DESCRIPTION
## Summary

- **MessageStore** (`internal/store`): Thread-safe in-memory store with pagination, sorting, full-text search, and oldest-first eviction at configurable capacity
- **Log mode** (`internal/catcher/handlers.go`): Severity-aware structured logging — maps message severity to slog levels (error→ERROR, warning→WARN, etc.)
- **FileCatcher** (`internal/catcher/file.go`): Reads messages from a JSON file for dev/testing without Redis
- **Pluggable handlers**: `MessageHandler` function type — catcher dispatches to registered handlers (log, store, or both)
- **Mode selection** (`main.go`): `CATCHER_MODE=log|cli|web` and `CATCHER_BACKEND=redis|file` env vars

## New env vars

| Variable | Default | Description |
|----------|---------|-------------|
| `CATCHER_MODE` | `log` | Operating mode |
| `CATCHER_BACKEND` | `redis` | Backend: `redis` or `file` |
| `CATCHER_FILE_PATH` | `messages.json` | JSON file path (file backend) |
| `CATCHER_FILE_INTERVAL` | `1s` | Replay interval (file backend) |
| `MAX_MESSAGES` | `10000` | Max messages in store (cli/web modes) |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (store unit tests)
- [ ] Deploy log mode to cluster and verify severity-aware logging

Closes #3, #4, #7, #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)