### PR TITLE
feat: CLI mode with interactive Bubble Tea TUI

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1,0 +1,294 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/models"
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/store"
+)
+
+const (
+	viewList   = iota
+	viewDetail
+)
+
+// refreshMsg triggers a UI refresh.
+type refreshMsg struct{}
+
+// Model is the top-level Bubble Tea model.
+type Model struct {
+	store      *store.MessageStore
+	view       int
+	table      tableModel
+	detail     detailModel
+	search     searchModel
+	width      int
+	height     int
+	sortField  store.SortField
+	sortDir    store.SortDirection
+	page       int
+	pageSize   int
+	searching  bool
+}
+
+// New creates a new TUI model.
+func New(s *store.MessageStore) Model {
+	return Model{
+		store:    s,
+		view:     viewList,
+		table:    newTable(),
+		detail:   newDetail(),
+		search:   newSearch(),
+		sortField: store.SortByTimestamp,
+		sortDir:  store.SortDesc,
+		page:     0,
+		pageSize: 20,
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return tea.Tick(time.Second, func(time.Time) tea.Msg {
+		return refreshMsg{}
+	})
+}
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case refreshMsg:
+		m.table.rows = m.fetchRows()
+		return m, tea.Tick(time.Second, func(time.Time) tea.Msg {
+			return refreshMsg{}
+		})
+
+	case tea.KeyMsg:
+		// Global keys
+		if !m.searching {
+			switch msg.String() {
+			case "q", "ctrl+c":
+				return m, tea.Quit
+			}
+		}
+
+		switch m.view {
+		case viewList:
+			return m.updateList(msg)
+		case viewDetail:
+			return m.updateDetail(msg)
+		}
+	}
+
+	return m, nil
+}
+
+func (m Model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.searching {
+		switch msg.String() {
+		case "enter":
+			m.searching = false
+			m.page = 0
+			m.table.rows = m.fetchRows()
+			return m, nil
+		case "esc":
+			m.searching = false
+			m.search.query = ""
+			m.page = 0
+			m.table.rows = m.fetchRows()
+			return m, nil
+		default:
+			m.search, _ = m.search.Update(msg)
+			m.page = 0
+			m.table.rows = m.fetchRows()
+			return m, nil
+		}
+	}
+
+	switch msg.String() {
+	case "/":
+		m.searching = true
+		m.search.Focus()
+		return m, nil
+	case "s":
+		m.sortField = (m.sortField + 1) % 5
+		m.table.rows = m.fetchRows()
+		return m, nil
+	case "S":
+		if m.sortDir == store.SortAsc {
+			m.sortDir = store.SortDesc
+		} else {
+			m.sortDir = store.SortAsc
+		}
+		m.table.rows = m.fetchRows()
+		return m, nil
+	case "j", "down":
+		if m.table.cursor < len(m.table.rows)-1 {
+			m.table.cursor++
+		}
+		return m, nil
+	case "k", "up":
+		if m.table.cursor > 0 {
+			m.table.cursor--
+		}
+		return m, nil
+	case "n", "right":
+		totalPages := m.totalPages()
+		if m.page < totalPages-1 {
+			m.page++
+			m.table.cursor = 0
+			m.table.rows = m.fetchRows()
+		}
+		return m, nil
+	case "p", "left":
+		if m.page > 0 {
+			m.page--
+			m.table.cursor = 0
+			m.table.rows = m.fetchRows()
+		}
+		return m, nil
+	case "enter":
+		if len(m.table.rows) > 0 && m.table.cursor < len(m.table.rows) {
+			m.detail.message = &m.table.rows[m.table.cursor]
+			m.view = viewDetail
+		}
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m Model) updateDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "backspace", "q":
+		m.view = viewList
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) View() tea.View {
+	var content string
+	if m.width == 0 {
+		content = "loading..."
+	} else {
+		switch m.view {
+		case viewDetail:
+			content = m.renderDetail()
+		default:
+			content = m.renderList()
+		}
+	}
+
+	v := tea.NewView(content)
+	v.AltScreen = true
+	return v
+}
+
+func (m Model) renderList() string {
+	var b strings.Builder
+
+	// Header
+	header := headerStyle.Width(m.width).Render(
+		fmt.Sprintf("  HOMERUN² core-catcher    [/] search  [s] sort  [S] dir  [n/p] page  [enter] detail  [q] quit"),
+	)
+	b.WriteString(header + "\n")
+
+	// Search bar
+	if m.searching {
+		b.WriteString(m.search.View() + "\n")
+	} else if m.search.query != "" {
+		b.WriteString(searchActiveStyle.Render(fmt.Sprintf("  filter: %s", m.search.query)) + "\n")
+	}
+
+	// Sort info
+	sortNames := []string{"timestamp", "severity", "system", "author", "title"}
+	dirName := "↓"
+	if m.sortDir == store.SortAsc {
+		dirName = "↑"
+	}
+	b.WriteString(sortInfoStyle.Render(fmt.Sprintf("  sort: %s %s", sortNames[m.sortField], dirName)) + "\n")
+
+	// Table
+	tableHeight := m.height - 7
+	if m.searching || m.search.query != "" {
+		tableHeight--
+	}
+	b.WriteString(m.table.Render(m.width, tableHeight))
+
+	// Footer
+	total := m.store.Count()
+	totalPages := m.totalPages()
+	footer := footerStyle.Width(m.width).Render(
+		fmt.Sprintf("  %d messages | page %d/%d | stream: messages", total, m.page+1, max(totalPages, 1)),
+	)
+	b.WriteString("\n" + footer)
+
+	return b.String()
+}
+
+func (m Model) renderDetail() string {
+	var b strings.Builder
+
+	header := headerStyle.Width(m.width).Render("  Message Detail    [esc/backspace] back")
+	b.WriteString(header + "\n\n")
+
+	if m.detail.message != nil {
+		b.WriteString(m.detail.Render(m.width))
+	}
+
+	return b.String()
+}
+
+func (m Model) fetchRows() []models.CaughtMessage {
+	if m.search.query != "" {
+		all := m.store.Search(m.search.query)
+		start := m.page * m.pageSize
+		if start >= len(all) {
+			return nil
+		}
+		end := start + m.pageSize
+		if end > len(all) {
+			end = len(all)
+		}
+		return all[start:end]
+	}
+	return m.store.List(store.ListOptions{
+		Offset:  m.page * m.pageSize,
+		Limit:   m.pageSize,
+		SortBy:  m.sortField,
+		SortDir: m.sortDir,
+	})
+}
+
+func (m Model) totalPages() int {
+	total := m.store.Count()
+	if total == 0 {
+		return 1
+	}
+	return (total + m.pageSize - 1) / m.pageSize
+}
+
+// Styles
+var (
+	headerStyle = lipgloss.NewStyle().
+		Background(lipgloss.Color("#00CC66")).
+		Foreground(lipgloss.Color("#000000")).
+		Bold(true)
+
+	footerStyle = lipgloss.NewStyle().
+		Background(lipgloss.Color("#333333")).
+		Foreground(lipgloss.Color("#CCCCCC"))
+
+	sortInfoStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#888888"))
+
+	searchActiveStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#FFAA00"))
+)

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -1,0 +1,66 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/models"
+)
+
+type detailModel struct {
+	message *models.CaughtMessage
+}
+
+func newDetail() detailModel {
+	return detailModel{}
+}
+
+func (d detailModel) Render(width int) string {
+	if d.message == nil {
+		return ""
+	}
+
+	m := d.message
+	var b strings.Builder
+
+	fields := []struct {
+		label string
+		value string
+	}{
+		{"Object ID", m.ObjectID},
+		{"Stream ID", m.StreamID},
+		{"Title", m.Title},
+		{"Message", m.Message.Message},
+		{"Severity", m.Severity},
+		{"Author", m.Author},
+		{"System", m.System},
+		{"Timestamp", m.Timestamp},
+		{"Caught At", m.CaughtAt.Format("2006-01-02 15:04:05")},
+		{"Tags", m.Tags},
+		{"Assignee", m.AssigneeName},
+		{"Assignee Addr", m.AssigneeAddress},
+		{"Artifacts", m.Artifacts},
+		{"URL", m.Url},
+	}
+
+	for _, f := range fields {
+		if f.value == "" {
+			continue
+		}
+		label := detailLabelStyle.Render(fmt.Sprintf("  %-15s", f.label))
+		value := detailValueStyle.Render(f.value)
+		b.WriteString(label + " " + value + "\n")
+	}
+
+	return b.String()
+}
+
+var (
+	detailLabelStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#00CC66")).
+		Bold(true)
+
+	detailValueStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#FFFFFF"))
+)

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -1,0 +1,43 @@
+package tui
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+type searchModel struct {
+	query   string
+	focused bool
+}
+
+func newSearch() searchModel {
+	return searchModel{}
+}
+
+func (s *searchModel) Focus() {
+	s.focused = true
+}
+
+func (s searchModel) Update(msg tea.KeyMsg) (searchModel, tea.Cmd) {
+	switch msg.String() {
+	case "backspace":
+		if len(s.query) > 0 {
+			s.query = s.query[:len(s.query)-1]
+		}
+	default:
+		if len(msg.String()) == 1 {
+			s.query += msg.String()
+		}
+	}
+	return s, nil
+}
+
+func (s searchModel) View() string {
+	return searchStyle.Render(fmt.Sprintf("  search: %s█", s.query))
+}
+
+var searchStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.Color("#FFAA00")).
+	Bold(true)

--- a/internal/tui/table.go
+++ b/internal/tui/table.go
@@ -1,0 +1,131 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/models"
+)
+
+type tableModel struct {
+	rows   []models.CaughtMessage
+	cursor int
+}
+
+func newTable() tableModel {
+	return tableModel{}
+}
+
+func (t tableModel) Render(width, maxRows int) string {
+	if len(t.rows) == 0 {
+		return emptyStyle.Render("  no messages yet — waiting for stream...")
+	}
+
+	// Column widths (proportional)
+	colTitle := width * 30 / 100
+	colSev := 10
+	colSystem := width * 18 / 100
+	colAuthor := width * 15 / 100
+	colTime := 20
+	colRemaining := width - colTitle - colSev - colSystem - colAuthor - colTime - 6
+	if colRemaining > 0 {
+		colTitle += colRemaining
+	}
+
+	var b strings.Builder
+
+	// Header row
+	hdr := fmt.Sprintf("  %-*s  %-*s  %-*s  %-*s  %-*s",
+		colTitle, "TITLE",
+		colSev, "SEVERITY",
+		colSystem, "SYSTEM",
+		colAuthor, "AUTHOR",
+		colTime, "TIMESTAMP",
+	)
+	b.WriteString(tableHeaderStyle.Width(width).Render(hdr) + "\n")
+
+	// Data rows
+	visible := t.rows
+	if maxRows > 0 && len(visible) > maxRows {
+		visible = visible[:maxRows]
+	}
+
+	for i, msg := range visible {
+		title := truncate(msg.Title, colTitle)
+		sev := truncate(msg.Severity, colSev)
+		sys := truncate(msg.System, colSystem)
+		author := truncate(msg.Author, colAuthor)
+		ts := truncate(msg.CaughtAt.Format(time.DateTime), colTime)
+
+		row := fmt.Sprintf("  %-*s  %-*s  %-*s  %-*s  %-*s",
+			colTitle, title,
+			colSev, sev,
+			colSystem, sys,
+			colAuthor, author,
+			colTime, ts,
+		)
+
+		style := rowStyle
+		if i == t.cursor {
+			style = selectedRowStyle
+		}
+
+		// Color severity
+		if i == t.cursor {
+			b.WriteString(style.Width(width).Render(row) + "\n")
+		} else {
+			styled := applySeverityColor(row, msg.Severity, style)
+			b.WriteString(styled + "\n")
+		}
+	}
+
+	return b.String()
+}
+
+func truncate(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}
+
+func applySeverityColor(row, severity string, base lipgloss.Style) string {
+	switch severity {
+	case "error":
+		return base.Foreground(lipgloss.Color("#FF4444")).Render(row)
+	case "warning":
+		return base.Foreground(lipgloss.Color("#FFAA00")).Render(row)
+	case "success":
+		return base.Foreground(lipgloss.Color("#00CC66")).Render(row)
+	case "debug":
+		return base.Foreground(lipgloss.Color("#888888")).Render(row)
+	default:
+		return base.Render(row)
+	}
+}
+
+var (
+	tableHeaderStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("#00CC66")).
+		Background(lipgloss.Color("#1A1A1A"))
+
+	rowStyle = lipgloss.NewStyle()
+
+	selectedRowStyle = lipgloss.NewStyle().
+		Background(lipgloss.Color("#004422")).
+		Foreground(lipgloss.Color("#FFFFFF")).
+		Bold(true)
+
+	emptyStyle = lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#666666")).
+		Italic(true)
+)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -9,10 +10,12 @@ import (
 	"syscall"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stuttgart-things/homerun2-core-catcher/internal/banner"
 	"github.com/stuttgart-things/homerun2-core-catcher/internal/catcher"
 	"github.com/stuttgart-things/homerun2-core-catcher/internal/config"
 	"github.com/stuttgart-things/homerun2-core-catcher/internal/store"
+	"github.com/stuttgart-things/homerun2-core-catcher/internal/tui"
 
 	homerun "github.com/stuttgart-things/homerun-library/v2"
 )
@@ -41,8 +44,10 @@ func main() {
 	// Build message handlers based on mode
 	var handlers []catcher.MessageHandler
 
-	// Log handler is always active
-	handlers = append(handlers, catcher.LogHandler())
+	// Log handler is always active (except cli mode where TUI owns the terminal)
+	if mode != "cli" {
+		handlers = append(handlers, catcher.LogHandler())
+	}
 
 	// Store handler for modes that need in-memory storage (cli, web)
 	var msgStore *store.MessageStore
@@ -50,7 +55,6 @@ func main() {
 		maxMessages, _ := strconv.Atoi(homerun.GetEnv("MAX_MESSAGES", "10000"))
 		msgStore = store.New(maxMessages)
 		handlers = append(handlers, catcher.StoreHandler(msgStore))
-		_ = msgStore // will be used by TUI/web in future
 	}
 
 	// Create catcher backend
@@ -92,27 +96,51 @@ func main() {
 		)
 	}
 
-	// Handle shutdown signals
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	switch mode {
+	case "cli":
+		// Run catcher in background, TUI in foreground
+		go c.Run()
 
-	// Collect errors
-	if errCh := c.Errors(); errCh != nil {
-		go func() {
-			for err := range errCh {
-				slog.Error("consumer error", "error", err)
-			}
-		}()
-	}
+		// Collect errors in background
+		if errCh := c.Errors(); errCh != nil {
+			go func() {
+				for err := range errCh {
+					slog.Error("consumer error", "error", err)
+				}
+			}()
+		}
 
-	go func() {
-		<-quit
-		slog.Info("shutting down catcher")
+		p := tea.NewProgram(tui.New(msgStore))
+		if _, err := p.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "TUI error: %v\n", err)
+			os.Exit(1)
+		}
+
 		c.Shutdown()
-	}()
 
-	slog.Info("catcher running, waiting for messages...")
-	c.Run()
+	default: // log, web
+		// Handle shutdown signals
+		quit := make(chan os.Signal, 1)
+		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 
-	slog.Info("catcher exited gracefully")
+		// Collect errors
+		if errCh := c.Errors(); errCh != nil {
+			go func() {
+				for err := range errCh {
+					slog.Error("consumer error", "error", err)
+				}
+			}()
+		}
+
+		go func() {
+			<-quit
+			slog.Info("shutting down catcher")
+			c.Shutdown()
+		}()
+
+		slog.Info("catcher running, waiting for messages...")
+		c.Run()
+
+		slog.Info("catcher exited gracefully")
+	}
 }


### PR DESCRIPTION
## Summary

- **Table view**: Paginated message list with severity-aware color coding (red=error, yellow=warning, green=success)
- **Search**: Full-text filter across all fields (`/` to start, `Enter` to apply, `Esc` to clear)
- **Sorting**: Cycle sort field with `s`, toggle direction with `S` (timestamp, severity, system, author, title)
- **Pagination**: `n`/`p` or arrow keys to navigate pages
- **Detail view**: `Enter` to expand message, shows all fields including tags, artifacts, URL, assignee
- **Live refresh**: Store polled every second for new messages
- **Alt screen**: Clean terminal experience, `q` to quit

## Usage

```bash
# With Redis
CATCHER_MODE=cli ./homerun2-core-catcher

# With file backend (dev/testing)
CATCHER_MODE=cli CATCHER_BACKEND=file CATCHER_FILE_PATH=messages.json ./homerun2-core-catcher
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Smoke test with file backend — TUI launches, messages display

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)