### PR TITLE
feat: add Service and HTTPRoute KCL manifests for web mode

### DIFF
--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -37,7 +37,24 @@ deployment = {
                         name: config.name
                         image: config.image
                         imagePullPolicy: config.imagePullPolicy
+                        if config.catcherMode == "web":
+                            ports: [
+                                {
+                                    name: "http"
+                                    containerPort: config.containerPort
+                                    protocol: "TCP"
+                                }
+                            ]
                         env: [
+                            {
+                                name: "CATCHER_MODE"
+                                value: config.catcherMode
+                            }
+                            if config.catcherMode == "web":
+                                {
+                                    name: "PORT"
+                                    value: str(config.containerPort)
+                                }
                             {
                                 name: "REDIS_ADDR"
                                 value: config.redisAddr
@@ -82,6 +99,28 @@ deployment = {
                                 memory: config.memoryLimit
                             }
                         }
+                        if config.catcherMode == "web":
+                            livenessProbe: {
+                                httpGet: {
+                                    path: "/health"
+                                    port: "http"
+                                }
+                                initialDelaySeconds: 10
+                                periodSeconds: 10
+                                timeoutSeconds: 5
+                                failureThreshold: 3
+                            }
+                        if config.catcherMode == "web":
+                            readinessProbe: {
+                                httpGet: {
+                                    path: "/health"
+                                    port: "http"
+                                }
+                                initialDelaySeconds: 5
+                                periodSeconds: 5
+                                timeoutSeconds: 3
+                                failureThreshold: 3
+                            }
                         securityContext: {
                             readOnlyRootFilesystem: True
                             runAsNonRoot: True

--- a/kcl/httproute.k
+++ b/kcl/httproute.k
@@ -1,0 +1,53 @@
+"""
+HTTPRoute (Gateway API) for homerun2-core-catcher
+"""
+
+import labels
+
+config = labels.config
+
+_hostname = config.httpRouteHostname
+
+httproute = {
+    apiVersion: "gateway.networking.k8s.io/v1"
+    kind: "HTTPRoute"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+        if config.annotations or config.httpRouteAnnotations:
+            annotations: {
+                **config.annotations
+                **config.httpRouteAnnotations
+            }
+    }
+    spec: {
+        parentRefs: [
+            {
+                name: config.httpRouteParentRefName
+                if config.httpRouteParentRefNamespace:
+                    namespace: config.httpRouteParentRefNamespace
+            }
+        ]
+        if _hostname:
+            hostnames: [_hostname]
+        rules: [
+            {
+                matches: [
+                    {
+                        path: {
+                            type: "PathPrefix"
+                            value: "/"
+                        }
+                    }
+                ]
+                backendRefs: [
+                    {
+                        name: config.name
+                        port: config.servicePort
+                    }
+                ]
+            }
+        ]
+    }
+} if config.httpRouteEnabled else None

--- a/kcl/labels.k
+++ b/kcl/labels.k
@@ -12,6 +12,12 @@ _redisPort = option("config.redisPort")
 _redisStream = option("config.redisStream")
 _consumerGroup = option("config.consumerGroup")
 _redisPassword = option("config.redisPassword")
+_httpRouteEnabled = option("config.httpRouteEnabled")
+_httpRouteParentRefName = option("config.httpRouteParentRefName")
+_httpRouteParentRefNamespace = option("config.httpRouteParentRefNamespace")
+_httpRouteHostname = option("config.httpRouteHostname")
+_httpRouteAnnotations = option("config.httpRouteAnnotations") or {}
+_catcherMode = option("config.catcherMode")
 _extraEnvVars = option("config.extraEnvVars") or {}
 
 # Config instance with command-line overrides
@@ -30,6 +36,18 @@ config: schema.CoreCatcher = schema.CoreCatcher {
         consumerGroup = _consumerGroup
     if _redisPassword:
         redisPassword = _redisPassword
+    if _httpRouteEnabled:
+        httpRouteEnabled = _httpRouteEnabled in [True, "True", "true"]
+    if _httpRouteParentRefName:
+        httpRouteParentRefName = _httpRouteParentRefName
+    if _httpRouteParentRefNamespace:
+        httpRouteParentRefNamespace = _httpRouteParentRefNamespace
+    if _httpRouteHostname:
+        httpRouteHostname = _httpRouteHostname
+    if _httpRouteAnnotations:
+        httpRouteAnnotations = _httpRouteAnnotations
+    if _catcherMode:
+        catcherMode = _catcherMode
     if _extraEnvVars:
         extraEnvVars = _extraEnvVars
 }

--- a/kcl/main.k
+++ b/kcl/main.k
@@ -8,6 +8,8 @@ import serviceaccount
 import configmap
 import secret
 import deploy
+import service
+import httproute
 
 # Export all manifests (filter out None values)
 manifests = [
@@ -17,5 +19,7 @@ manifests = [
         configmap.configMap
         secret.secretRedis
         deploy.deployment
+        service.service
+        httproute.httproute
     ] if m
 ]

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -28,8 +28,23 @@ schema CoreCatcher:
     # Consumer group
     consumerGroup: str = "homerun2-core-catcher"
 
+    # Service
+    serviceType: str = "ClusterIP"
+    servicePort: int = 80
+    containerPort: int = 8080
+
+    # HTTPRoute (Gateway API)
+    httpRouteEnabled: bool = False
+    httpRouteParentRefName: str = ""
+    httpRouteParentRefNamespace: str = ""
+    httpRouteHostname: str = ""
+    httpRouteAnnotations: {str:str} = {}
+
     # Secrets
     redisPassword: str = ""
+
+    # Catcher mode
+    catcherMode: str = "log"
 
     # Extra environment variables
     extraEnvVars: {str:str} = {}
@@ -40,5 +55,7 @@ schema CoreCatcher:
 
     check:
         replicas >= 0, "replicas must be >= 0"
+        servicePort >= 1 and servicePort <= 65535, "servicePort must be valid"
+        containerPort >= 1 and containerPort <= 65535, "containerPort must be valid"
         name != "", "name must not be empty"
         namespace != "", "namespace must not be empty"

--- a/kcl/service.k
+++ b/kcl/service.k
@@ -1,0 +1,29 @@
+"""
+Service for homerun2-core-catcher
+"""
+
+import labels
+
+config = labels.config
+
+service = {
+    apiVersion: "v1"
+    kind: "Service"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    spec: {
+        type: config.serviceType
+        ports: [
+            {
+                name: "http"
+                port: config.servicePort
+                targetPort: "http"
+                protocol: "TCP"
+            }
+        ]
+        selector: labels.selectorLabels
+    }
+} if config.catcherMode == "web" else None

--- a/tests/kcl-movie-scripts-profile.yaml
+++ b/tests/kcl-movie-scripts-profile.yaml
@@ -5,3 +5,8 @@ config.redisPort: "6379"
 config.redisStream: messages
 config.consumerGroup: homerun2-core-catcher
 config.redisPassword: changeme # pragma: allowlist secret
+config.catcherMode: web
+config.httpRouteEnabled: "true"
+config.httpRouteHostname: homerun2-core-catcher.movie-scripts2.sthings-vsphere.labul.sva.de
+config.httpRouteParentRefName: sthings-gateway
+config.httpRouteParentRefNamespace: kube-system


### PR DESCRIPTION
## Summary
- Add `service.k` and `httproute.k` KCL manifests for Gateway API routing
- Extend `schema.k` with service, HTTPRoute, and catcherMode fields
- Update `deploy.k` with container port, CATCHER_MODE env, and health probes for web mode
- Update movie-scripts deploy profile with HTTPRoute config

## Test plan
- [ ] Run `kcl run kcl/main.k -D config.catcherMode=web -D config.httpRouteEnabled=true ...` to verify manifests
- [ ] Deploy to movie-scripts cluster via `task deploy-kcl`
- [ ] Verify HTTPRoute resolves and web dashboard is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)