### PR TITLE
feat: add filter dropdowns for System, Severity, Author and time range

### DIFF
--- a/internal/handlers/export.go
+++ b/internal/handlers/export.go
@@ -17,7 +17,7 @@ func ExportHandler(s *store.MessageStore) http.HandlerFunc {
 			format = "json"
 		}
 
-		messages := s.List(store.ListOptions{
+		result := s.List(store.ListOptions{
 			SortBy:  store.SortByTimestamp,
 			SortDir: store.SortDesc,
 		})
@@ -30,7 +30,7 @@ func ExportHandler(s *store.MessageStore) http.HandlerFunc {
 			writer := csv.NewWriter(w)
 			writer.Write([]string{"ObjectID", "Title", "Message", "Severity", "Author", "System", "Timestamp", "Tags"})
 
-			for _, m := range messages {
+			for _, m := range result.Messages {
 				writer.Write([]string{
 					m.ObjectID,
 					m.Title,
@@ -49,7 +49,7 @@ func ExportHandler(s *store.MessageStore) http.HandlerFunc {
 			w.Header().Set("Content-Disposition", "attachment; filename=messages.json")
 			enc := json.NewEncoder(w)
 			enc.SetIndent("", "  ")
-			if err := enc.Encode(messages); err != nil {
+			if err := enc.Encode(result.Messages); err != nil {
 				http.Error(w, fmt.Sprintf("export error: %v", err), http.StatusInternalServerError)
 			}
 		}

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -1,11 +1,11 @@
 package handlers
 
 import (
-	"fmt"
 	"html/template"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/stuttgart-things/homerun2-core-catcher/internal/store"
 	"github.com/stuttgart-things/homerun2-core-catcher/internal/web"
@@ -78,16 +78,42 @@ func MessageDetailHandler(s *store.MessageStore) http.HandlerFunc {
 }
 
 type tableData struct {
-	Messages  interface{}
-	Query     string
-	SortBy    string
-	SortDir   string
-	Page      int
-	PageSize  int
-	Total     int
+	Messages   interface{}
+	Query      string
+	SortBy     string
+	SortDir    string
+	Page       int
+	PageSize   int
+	Total      int
+	TotalAll   int
 	TotalPages int
-	HasPrev   bool
-	HasNext   bool
+	HasPrev    bool
+	HasNext    bool
+	// Filter values
+	FilterSystem   string
+	FilterSeverity string
+	FilterAuthor   string
+	FilterTime     string
+	// Distinct values for dropdowns
+	Systems    []string
+	Severities []string
+	Authors    []string
+}
+
+// parseSinceDuration converts a time filter string to a duration.
+func parseSinceDuration(s string) time.Duration {
+	switch s {
+	case "1h":
+		return time.Hour
+	case "6h":
+		return 6 * time.Hour
+	case "24h":
+		return 24 * time.Hour
+	case "7d":
+		return 7 * 24 * time.Hour
+	default:
+		return 0
+	}
 }
 
 func buildTableData(s *store.MessageStore, r *http.Request) tableData {
@@ -98,6 +124,12 @@ func buildTableData(s *store.MessageStore, r *http.Request) tableData {
 	sortDir := q.Get("dir")
 	pageStr := q.Get("page")
 	pageSizeStr := q.Get("size")
+
+	// Filter params
+	filterSystem := q.Get("system")
+	filterSeverity := q.Get("severity")
+	filterAuthor := q.Get("author")
+	filterTime := q.Get("time")
 
 	page, _ := strconv.Atoi(pageStr)
 	if page < 0 {
@@ -132,55 +164,44 @@ func buildTableData(s *store.MessageStore, r *http.Request) tableData {
 		dir = store.SortAsc
 	}
 
-	var messages interface{}
-	var total int
+	result := s.List(store.ListOptions{
+		Offset:  page * pageSize,
+		Limit:   pageSize,
+		SortBy:  sortField,
+		SortDir: dir,
+		Filter: store.FilterOptions{
+			System:   filterSystem,
+			Severity: filterSeverity,
+			Author:   filterAuthor,
+			Since:    parseSinceDuration(filterTime),
+			Query:    query,
+		},
+	})
 
-	if query != "" {
-		all := s.Search(query)
-		total = len(all)
-		start := page * pageSize
-		if start >= total {
-			messages = nil
-		} else {
-			end := start + pageSize
-			if end > total {
-				end = total
-			}
-			slice := all[start:end]
-			messages = slice
-		}
-	} else {
-		total = s.Count()
-		messages = s.List(store.ListOptions{
-			Offset:  page * pageSize,
-			Limit:   pageSize,
-			SortBy:  sortField,
-			SortDir: dir,
-		})
-	}
-
+	total := result.Total
 	totalPages := 1
 	if total > 0 {
 		totalPages = (total + pageSize - 1) / pageSize
 	}
 
-	// Toggle sort direction for column header links
-	nextDir := "asc"
-	if sortDir == "asc" {
-		nextDir = "desc"
-	}
-	_ = nextDir
-
 	return tableData{
-		Messages:   messages,
-		Query:      query,
-		SortBy:     sortBy,
-		SortDir:    fmt.Sprintf("%s", sortDir),
-		Page:       page,
-		PageSize:   pageSize,
-		Total:      total,
-		TotalPages: totalPages,
-		HasPrev:    page > 0,
-		HasNext:    page < totalPages-1,
+		Messages:       result.Messages,
+		Query:          query,
+		SortBy:         sortBy,
+		SortDir:        sortDir,
+		Page:           page,
+		PageSize:       pageSize,
+		Total:          total,
+		TotalAll:       s.Count(),
+		TotalPages:     totalPages,
+		HasPrev:        page > 0,
+		HasNext:        page < totalPages-1,
+		FilterSystem:   filterSystem,
+		FilterSeverity: filterSeverity,
+		FilterAuthor:   filterAuthor,
+		FilterTime:     filterTime,
+		Systems:        s.DistinctSystems(),
+		Severities:     s.DistinctSeverities(),
+		Authors:        s.DistinctAuthors(),
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,8 +1,10 @@
 package store
 
 import (
+	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/stuttgart-things/homerun2-core-catcher/internal/models"
 )
@@ -26,12 +28,28 @@ const (
 	SortDesc
 )
 
-// ListOptions controls pagination and sorting.
+// FilterOptions controls which messages to include.
+type FilterOptions struct {
+	System   string // exact match (empty = all)
+	Severity string // exact match (empty = all)
+	Author   string // exact match (empty = all)
+	Since    time.Duration // only messages newer than this (0 = all)
+	Query    string // free-text search across all fields
+}
+
+// ListOptions controls pagination, sorting, and filtering.
 type ListOptions struct {
-	Offset    int
-	Limit     int
-	SortBy    SortField
-	SortDir   SortDirection
+	Offset  int
+	Limit   int
+	SortBy  SortField
+	SortDir SortDirection
+	Filter  FilterOptions
+}
+
+// ListResult contains paginated results with total count.
+type ListResult struct {
+	Messages []models.CaughtMessage
+	Total    int
 }
 
 // MessageStore holds caught messages in memory.
@@ -74,25 +92,27 @@ func (s *MessageStore) Add(msg models.CaughtMessage) {
 	s.messages = append(s.messages, msg)
 }
 
-// List returns messages according to the given options.
-func (s *MessageStore) List(opts ListOptions) []models.CaughtMessage {
+// List returns messages according to the given options, applying filters first.
+func (s *MessageStore) List(opts ListOptions) ListResult {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	sorted := s.sorted(opts.SortBy, opts.SortDir)
+	filtered := s.applyFilters(opts.Filter)
+	sortMessages(filtered, opts.SortBy, opts.SortDir)
 
-	if opts.Offset >= len(sorted) {
-		return nil
+	total := len(filtered)
+	if opts.Offset >= total {
+		return ListResult{Total: total}
 	}
 
 	end := opts.Offset + opts.Limit
-	if opts.Limit <= 0 || end > len(sorted) {
-		end = len(sorted)
+	if opts.Limit <= 0 || end > total {
+		end = total
 	}
 
 	result := make([]models.CaughtMessage, end-opts.Offset)
-	copy(result, sorted[opts.Offset:end])
-	return result
+	copy(result, filtered[opts.Offset:end])
+	return ListResult{Messages: result, Total: total}
 }
 
 // Search returns messages where any field contains the query string (case-insensitive).
@@ -130,6 +150,73 @@ func (s *MessageStore) Count() int {
 	return len(s.messages)
 }
 
+// DistinctSystems returns all unique system values.
+func (s *MessageStore) DistinctSystems() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.distinctField(func(m models.CaughtMessage) string { return m.System })
+}
+
+// DistinctSeverities returns all unique severity values.
+func (s *MessageStore) DistinctSeverities() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.distinctField(func(m models.CaughtMessage) string { return m.Severity })
+}
+
+// DistinctAuthors returns all unique author values.
+func (s *MessageStore) DistinctAuthors() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.distinctField(func(m models.CaughtMessage) string { return m.Author })
+}
+
+func (s *MessageStore) distinctField(extract func(models.CaughtMessage) string) []string {
+	seen := make(map[string]struct{})
+	for _, m := range s.messages {
+		v := extract(m)
+		if v != "" {
+			seen[v] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(seen))
+	for v := range seen {
+		result = append(result, v)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func (s *MessageStore) applyFilters(f FilterOptions) []models.CaughtMessage {
+	var cutoff time.Time
+	if f.Since > 0 {
+		cutoff = time.Now().Add(-f.Since)
+	}
+
+	q := strings.ToLower(f.Query)
+
+	result := make([]models.CaughtMessage, 0, len(s.messages))
+	for _, m := range s.messages {
+		if f.System != "" && m.System != f.System {
+			continue
+		}
+		if f.Severity != "" && m.Severity != f.Severity {
+			continue
+		}
+		if f.Author != "" && m.Author != f.Author {
+			continue
+		}
+		if !cutoff.IsZero() && m.CaughtAt.Before(cutoff) {
+			continue
+		}
+		if q != "" && !matchesQuery(m, q) {
+			continue
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
 func matchesQuery(m models.CaughtMessage, q string) bool {
 	fields := []string{
 		m.Title, m.Message.Message, m.Severity, m.Author,
@@ -143,35 +230,25 @@ func matchesQuery(m models.CaughtMessage, q string) bool {
 	return false
 }
 
-func (s *MessageStore) sorted(by SortField, dir SortDirection) []models.CaughtMessage {
-	cp := make([]models.CaughtMessage, len(s.messages))
-	copy(cp, s.messages)
-
-	less := func(i, j int) bool {
-		var a, b string
+func sortMessages(msgs []models.CaughtMessage, by SortField, dir SortDirection) {
+	slices.SortFunc(msgs, func(a, b models.CaughtMessage) int {
+		var va, vb string
 		switch by {
 		case SortBySeverity:
-			a, b = cp[i].Severity, cp[j].Severity
+			va, vb = a.Severity, b.Severity
 		case SortBySystem:
-			a, b = cp[i].System, cp[j].System
+			va, vb = a.System, b.System
 		case SortByAuthor:
-			a, b = cp[i].Author, cp[j].Author
+			va, vb = a.Author, b.Author
 		case SortByTitle:
-			a, b = cp[i].Title, cp[j].Title
+			va, vb = a.Title, b.Title
 		default: // SortByTimestamp
-			a, b = cp[i].CaughtAt.String(), cp[j].CaughtAt.String()
+			va, vb = a.CaughtAt.String(), b.CaughtAt.String()
 		}
+		cmp := strings.Compare(va, vb)
 		if dir == SortDesc {
-			return a > b
+			return -cmp
 		}
-		return a < b
-	}
-
-	// simple insertion sort (fine for bounded store)
-	for i := 1; i < len(cp); i++ {
-		for j := i; j > 0 && less(j, j-1); j-- {
-			cp[j], cp[j-1] = cp[j-1], cp[j]
-		}
-	}
-	return cp
+		return cmp
+	})
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -90,6 +90,20 @@ func TestSearch(t *testing.T) {
 	}
 }
 
+func newMsgWithAuthor(id, title, severity, system, author string, caughtAt time.Time) models.CaughtMessage {
+	return models.CaughtMessage{
+		Message: homerun.Message{
+			Title:    title,
+			Severity: severity,
+			System:   system,
+			Author:   author,
+		},
+		ObjectID: id,
+		StreamID: "messages",
+		CaughtAt: caughtAt,
+	}
+}
+
 func TestList(t *testing.T) {
 	s := New(100)
 	for i := 0; i < 10; i++ {
@@ -97,15 +111,18 @@ func TestList(t *testing.T) {
 	}
 
 	// pagination
-	page := s.List(ListOptions{Offset: 2, Limit: 3})
-	if len(page) != 3 {
-		t.Fatalf("expected 3, got %d", len(page))
+	result := s.List(ListOptions{Offset: 2, Limit: 3})
+	if len(result.Messages) != 3 {
+		t.Fatalf("expected 3, got %d", len(result.Messages))
+	}
+	if result.Total != 10 {
+		t.Fatalf("expected total 10, got %d", result.Total)
 	}
 
 	// no limit
 	all := s.List(ListOptions{})
-	if len(all) != 10 {
-		t.Fatalf("expected 10, got %d", len(all))
+	if len(all.Messages) != 10 {
+		t.Fatalf("expected 10, got %d", len(all.Messages))
 	}
 }
 
@@ -116,12 +133,154 @@ func TestListSorted(t *testing.T) {
 	s.Add(newMsg("3", "Middle", "warning", "ci"))
 
 	result := s.List(ListOptions{SortBy: SortByTitle, SortDir: SortAsc})
-	if result[0].Title != "Alpha" || result[2].Title != "Zebra" {
-		t.Fatalf("expected sorted asc by title, got %v", []string{result[0].Title, result[1].Title, result[2].Title})
+	if result.Messages[0].Title != "Alpha" || result.Messages[2].Title != "Zebra" {
+		t.Fatalf("expected sorted asc by title, got %v", []string{result.Messages[0].Title, result.Messages[1].Title, result.Messages[2].Title})
 	}
 
 	result = s.List(ListOptions{SortBy: SortByTitle, SortDir: SortDesc})
-	if result[0].Title != "Zebra" || result[2].Title != "Alpha" {
+	if result.Messages[0].Title != "Zebra" || result.Messages[2].Title != "Alpha" {
 		t.Fatalf("expected sorted desc by title")
+	}
+}
+
+func TestFilterBySystem(t *testing.T) {
+	s := New(100)
+	s.Add(newMsg("1", "msg1", "info", "movie-scripts"))
+	s.Add(newMsg("2", "msg2", "error", "labul-staging"))
+	s.Add(newMsg("3", "msg3", "info", "movie-scripts"))
+
+	result := s.List(ListOptions{Filter: FilterOptions{System: "movie-scripts"}})
+	if result.Total != 2 {
+		t.Fatalf("expected 2 filtered by system, got %d", result.Total)
+	}
+	for _, m := range result.Messages {
+		if m.System != "movie-scripts" {
+			t.Fatalf("expected system movie-scripts, got %q", m.System)
+		}
+	}
+}
+
+func TestFilterBySeverity(t *testing.T) {
+	s := New(100)
+	s.Add(newMsg("1", "msg1", "info", "ci"))
+	s.Add(newMsg("2", "msg2", "error", "ci"))
+	s.Add(newMsg("3", "msg3", "error", "ci"))
+	s.Add(newMsg("4", "msg4", "warning", "ci"))
+
+	result := s.List(ListOptions{Filter: FilterOptions{Severity: "error"}})
+	if result.Total != 2 {
+		t.Fatalf("expected 2 errors, got %d", result.Total)
+	}
+}
+
+func TestFilterByAuthor(t *testing.T) {
+	s := New(100)
+	now := time.Now()
+	s.Add(newMsgWithAuthor("1", "msg1", "info", "ci", "k8s-pitcher", now))
+	s.Add(newMsgWithAuthor("2", "msg2", "info", "ci", "omni-pitcher", now))
+	s.Add(newMsgWithAuthor("3", "msg3", "info", "ci", "k8s-pitcher", now))
+
+	result := s.List(ListOptions{Filter: FilterOptions{Author: "k8s-pitcher"}})
+	if result.Total != 2 {
+		t.Fatalf("expected 2 by author, got %d", result.Total)
+	}
+}
+
+func TestFilterByTime(t *testing.T) {
+	s := New(100)
+	now := time.Now()
+	s.Add(newMsgWithAuthor("1", "old", "info", "ci", "test", now.Add(-2*time.Hour)))
+	s.Add(newMsgWithAuthor("2", "recent", "info", "ci", "test", now.Add(-30*time.Minute)))
+	s.Add(newMsgWithAuthor("3", "newest", "info", "ci", "test", now.Add(-5*time.Minute)))
+
+	result := s.List(ListOptions{Filter: FilterOptions{Since: time.Hour}})
+	if result.Total != 2 {
+		t.Fatalf("expected 2 within last hour, got %d", result.Total)
+	}
+}
+
+func TestFilterCombined(t *testing.T) {
+	s := New(100)
+	now := time.Now()
+	s.Add(newMsgWithAuthor("1", "msg1", "error", "movie-scripts", "k8s-pitcher", now.Add(-30*time.Minute)))
+	s.Add(newMsgWithAuthor("2", "msg2", "info", "movie-scripts", "k8s-pitcher", now.Add(-30*time.Minute)))
+	s.Add(newMsgWithAuthor("3", "msg3", "error", "labul", "k8s-pitcher", now.Add(-30*time.Minute)))
+	s.Add(newMsgWithAuthor("4", "msg4", "error", "movie-scripts", "omni", now.Add(-30*time.Minute)))
+	s.Add(newMsgWithAuthor("5", "msg5", "error", "movie-scripts", "k8s-pitcher", now.Add(-2*time.Hour)))
+
+	result := s.List(ListOptions{
+		Filter: FilterOptions{
+			System:   "movie-scripts",
+			Severity: "error",
+			Author:   "k8s-pitcher",
+			Since:    time.Hour,
+		},
+	})
+	if result.Total != 1 {
+		t.Fatalf("expected 1 combined filter match, got %d", result.Total)
+	}
+	if result.Messages[0].ObjectID != "1" {
+		t.Fatalf("expected message 1, got %q", result.Messages[0].ObjectID)
+	}
+}
+
+func TestFilterWithQuery(t *testing.T) {
+	s := New(100)
+	s.Add(newMsg("1", "Deploy complete", "success", "movie-scripts"))
+	s.Add(newMsg("2", "Deploy failed", "error", "movie-scripts"))
+	s.Add(newMsg("3", "Build ok", "success", "movie-scripts"))
+
+	result := s.List(ListOptions{Filter: FilterOptions{Query: "deploy", Severity: "error"}})
+	if result.Total != 1 {
+		t.Fatalf("expected 1 result for query+severity filter, got %d", result.Total)
+	}
+}
+
+func TestDistinctSystems(t *testing.T) {
+	s := New(100)
+	s.Add(newMsg("1", "msg1", "info", "movie-scripts"))
+	s.Add(newMsg("2", "msg2", "info", "labul"))
+	s.Add(newMsg("3", "msg3", "info", "movie-scripts"))
+
+	systems := s.DistinctSystems()
+	if len(systems) != 2 {
+		t.Fatalf("expected 2 systems, got %d", len(systems))
+	}
+	if systems[0] != "labul" || systems[1] != "movie-scripts" {
+		t.Fatalf("expected [labul, movie-scripts], got %v", systems)
+	}
+}
+
+func TestDistinctSeverities(t *testing.T) {
+	s := New(100)
+	s.Add(newMsg("1", "msg1", "info", "ci"))
+	s.Add(newMsg("2", "msg2", "error", "ci"))
+	s.Add(newMsg("3", "msg3", "info", "ci"))
+
+	sev := s.DistinctSeverities()
+	if len(sev) != 2 {
+		t.Fatalf("expected 2 severities, got %d: %v", len(sev), sev)
+	}
+}
+
+func TestFilterWithPagination(t *testing.T) {
+	s := New(100)
+	for i := 0; i < 10; i++ {
+		s.Add(newMsg(fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i), "error", "ci"))
+	}
+	for i := 10; i < 20; i++ {
+		s.Add(newMsg(fmt.Sprintf("%d", i), fmt.Sprintf("msg-%d", i), "info", "ci"))
+	}
+
+	result := s.List(ListOptions{
+		Offset: 0,
+		Limit:  5,
+		Filter: FilterOptions{Severity: "error"},
+	})
+	if result.Total != 10 {
+		t.Fatalf("expected total 10 errors, got %d", result.Total)
+	}
+	if len(result.Messages) != 5 {
+		t.Fatalf("expected 5 on page, got %d", len(result.Messages))
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -247,24 +247,16 @@ func (m Model) renderDetail() string {
 }
 
 func (m Model) fetchRows() []models.CaughtMessage {
-	if m.search.query != "" {
-		all := m.store.Search(m.search.query)
-		start := m.page * m.pageSize
-		if start >= len(all) {
-			return nil
-		}
-		end := start + m.pageSize
-		if end > len(all) {
-			end = len(all)
-		}
-		return all[start:end]
-	}
-	return m.store.List(store.ListOptions{
+	result := m.store.List(store.ListOptions{
 		Offset:  m.page * m.pageSize,
 		Limit:   m.pageSize,
 		SortBy:  m.sortField,
 		SortDir: m.sortDir,
+		Filter: store.FilterOptions{
+			Query: m.search.query,
+		},
 	})
+	return result.Messages
 }
 
 func (m Model) totalPages() int {

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -23,10 +23,13 @@
         .detail-panel { background: var(--pico-card-background-color); border: 1px solid var(--pico-muted-border-color); padding: 1.5rem; border-radius: 0.5rem; margin-bottom: 1rem; }
         .detail-panel dt { color: #00cc66; font-weight: bold; }
         .detail-panel dd { margin-bottom: 0.5rem; margin-left: 0; }
-        .controls { display: flex; gap: 1rem; align-items: center; flex-wrap: wrap; margin-bottom: 1rem; }
-        .controls input[type="search"] { max-width: 300px; margin: 0; }
+        .controls { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; margin-bottom: 1rem; }
+        .controls input[type="search"] { max-width: 250px; margin: 0; }
+        .controls select { max-width: 180px; margin: 0; padding: 0.4rem 0.6rem; font-size: 0.85rem; }
         .page-info { color: var(--pico-muted-color); font-size: 0.85rem; }
         .pagination { display: flex; gap: 0.5rem; align-items: center; }
+        .filter-count { font-size: 0.85rem; color: var(--pico-muted-color); }
+        .filter-count strong { color: #00cc66; }
     </style>
 </head>
 <body>
@@ -39,17 +42,64 @@
     </div>
     <main class="container-fluid">
         <div class="controls">
-            <input type="search" name="q" placeholder="Search messages..."
+            <input type="search" name="q" placeholder="Search..."
                    value="{{.Query}}"
                    hx-get="/messages"
                    hx-trigger="input changed delay:300ms, search"
                    hx-target="#message-table"
-                   hx-include="[name='sort'],[name='dir'],[name='size']"
+                   hx-include=".filter-control"
                    hx-push-url="true">
-            <input type="hidden" name="sort" value="{{.SortBy}}">
-            <input type="hidden" name="dir" value="{{.SortDir}}">
-            <input type="hidden" name="size" value="{{.PageSize}}">
-            <span class="page-info">{{.Total}} messages</span>
+
+            <select name="system" class="filter-control"
+                    hx-get="/messages"
+                    hx-trigger="change"
+                    hx-target="#message-table"
+                    hx-include="[name='q'],[name='sort'],[name='dir'],[name='size'],.filter-control">
+                <option value="">All Systems</option>
+                {{range .Systems}}
+                <option value="{{.}}" {{if eq . $.FilterSystem}}selected{{end}}>{{.}}</option>
+                {{end}}
+            </select>
+
+            <select name="severity" class="filter-control"
+                    hx-get="/messages"
+                    hx-trigger="change"
+                    hx-target="#message-table"
+                    hx-include="[name='q'],[name='sort'],[name='dir'],[name='size'],.filter-control">
+                <option value="">All Severities</option>
+                {{range .Severities}}
+                <option value="{{.}}" {{if eq . $.FilterSeverity}}selected{{end}}>{{.}}</option>
+                {{end}}
+            </select>
+
+            <select name="author" class="filter-control"
+                    hx-get="/messages"
+                    hx-trigger="change"
+                    hx-target="#message-table"
+                    hx-include="[name='q'],[name='sort'],[name='dir'],[name='size'],.filter-control">
+                <option value="">All Authors</option>
+                {{range .Authors}}
+                <option value="{{.}}" {{if eq . $.FilterAuthor}}selected{{end}}>{{.}}</option>
+                {{end}}
+            </select>
+
+            <select name="time" class="filter-control"
+                    hx-get="/messages"
+                    hx-trigger="change"
+                    hx-target="#message-table"
+                    hx-include="[name='q'],[name='sort'],[name='dir'],[name='size'],.filter-control">
+                <option value="" {{if eq .FilterTime ""}}selected{{end}}>All Time</option>
+                <option value="1h" {{if eq .FilterTime "1h"}}selected{{end}}>Last 1h</option>
+                <option value="6h" {{if eq .FilterTime "6h"}}selected{{end}}>Last 6h</option>
+                <option value="24h" {{if eq .FilterTime "24h"}}selected{{end}}>Last 24h</option>
+                <option value="7d" {{if eq .FilterTime "7d"}}selected{{end}}>Last 7d</option>
+            </select>
+
+            <input type="hidden" name="sort" class="filter-control" value="{{.SortBy}}">
+            <input type="hidden" name="dir" class="filter-control" value="{{.SortDir}}">
+            <input type="hidden" name="size" class="filter-control" value="{{.PageSize}}">
+
+            <span class="filter-count"><strong>{{.Total}}</strong> / {{.TotalAll}} messages</span>
         </div>
 
         <div id="message-detail"></div>

--- a/internal/web/templates/table.html
+++ b/internal/web/templates/table.html
@@ -2,29 +2,29 @@
 <table>
     <thead>
         <tr>
-            <th hx-get="/messages?sort=title&dir={{if and (eq .SortBy "title") (eq .SortDir "asc")}}desc{{else}}asc{{end}}&q={{.Query}}&size={{.PageSize}}"
+            <th hx-get="/messages?sort=title&dir={{if and (eq .SortBy "title") (eq .SortDir "asc")}}desc{{else}}asc{{end}}&q={{.Query}}&size={{.PageSize}}&system={{.FilterSystem}}&severity={{.FilterSeverity}}&author={{.FilterAuthor}}&time={{.FilterTime}}"
                 hx-target="#message-table" style="cursor:pointer">
                 Title {{if eq .SortBy "title"}}{{if eq .SortDir "asc"}}↑{{else}}↓{{end}}{{end}}
             </th>
-            <th hx-get="/messages?sort=severity&dir={{if and (eq .SortBy "severity") (eq .SortDir "asc")}}desc{{else}}asc{{end}}&q={{.Query}}&size={{.PageSize}}"
+            <th hx-get="/messages?sort=severity&dir={{if and (eq .SortBy "severity") (eq .SortDir "asc")}}desc{{else}}asc{{end}}&q={{.Query}}&size={{.PageSize}}&system={{.FilterSystem}}&severity={{.FilterSeverity}}&author={{.FilterAuthor}}&time={{.FilterTime}}"
                 hx-target="#message-table" style="cursor:pointer">
                 Severity {{if eq .SortBy "severity"}}{{if eq .SortDir "asc"}}↑{{else}}↓{{end}}{{end}}
             </th>
-            <th hx-get="/messages?sort=system&dir={{if and (eq .SortBy "system") (eq .SortDir "asc")}}desc{{else}}asc{{end}}&q={{.Query}}&size={{.PageSize}}"
+            <th hx-get="/messages?sort=system&dir={{if and (eq .SortBy "system") (eq .SortDir "asc")}}desc{{else}}asc{{end}}&q={{.Query}}&size={{.PageSize}}&system={{.FilterSystem}}&severity={{.FilterSeverity}}&author={{.FilterAuthor}}&time={{.FilterTime}}"
                 hx-target="#message-table" style="cursor:pointer">
                 System {{if eq .SortBy "system"}}{{if eq .SortDir "asc"}}↑{{else}}↓{{end}}{{end}}
             </th>
-            <th hx-get="/messages?sort=author&dir={{if and (eq .SortBy "author") (eq .SortDir "asc")}}desc{{else}}asc{{end}}&q={{.Query}}&size={{.PageSize}}"
+            <th hx-get="/messages?sort=author&dir={{if and (eq .SortBy "author") (eq .SortDir "asc")}}desc{{else}}asc{{end}}&q={{.Query}}&size={{.PageSize}}&system={{.FilterSystem}}&severity={{.FilterSeverity}}&author={{.FilterAuthor}}&time={{.FilterTime}}"
                 hx-target="#message-table" style="cursor:pointer">
                 Author {{if eq .SortBy "author"}}{{if eq .SortDir "asc"}}↑{{else}}↓{{end}}{{end}}
             </th>
-            <th hx-get="/messages?sort=timestamp&dir={{if and (eq .SortBy "timestamp") (eq .SortDir "asc")}}desc{{else}}asc{{end}}&q={{.Query}}&size={{.PageSize}}"
+            <th hx-get="/messages?sort=timestamp&dir={{if and (eq .SortBy "timestamp") (eq .SortDir "asc")}}desc{{else}}asc{{end}}&q={{.Query}}&size={{.PageSize}}&system={{.FilterSystem}}&severity={{.FilterSeverity}}&author={{.FilterAuthor}}&time={{.FilterTime}}"
                 hx-target="#message-table" style="cursor:pointer">
                 Time {{if eq .SortBy "timestamp"}}{{if eq .SortDir "asc"}}↑{{else}}↓{{end}}{{end}}
             </th>
         </tr>
     </thead>
-    <tbody hx-get="/messages?sort={{.SortBy}}&dir={{.SortDir}}&q={{.Query}}&page={{.Page}}&size={{.PageSize}}"
+    <tbody hx-get="/messages?sort={{.SortBy}}&dir={{.SortDir}}&q={{.Query}}&page={{.Page}}&size={{.PageSize}}&system={{.FilterSystem}}&severity={{.FilterSeverity}}&author={{.FilterAuthor}}&time={{.FilterTime}}"
            hx-trigger="every 5s"
            hx-target="#message-table"
            hx-swap="innerHTML">
@@ -40,19 +40,19 @@
             <td>{{.CaughtAt.Format "2006-01-02 15:04:05"}}</td>
         </tr>
         {{else}}
-        <tr><td colspan="5" style="text-align:center;color:var(--pico-muted-color)">No messages yet — waiting for stream...</td></tr>
+        <tr><td colspan="5" style="text-align:center;color:var(--pico-muted-color)">No messages match the current filters</td></tr>
         {{end}}
     </tbody>
 </table>
 
 <div class="pagination">
     {{if .HasPrev}}
-    <a href="#" hx-get="/messages?sort={{.SortBy}}&dir={{.SortDir}}&q={{.Query}}&page={{sub .Page 1}}&size={{.PageSize}}"
+    <a href="#" hx-get="/messages?sort={{.SortBy}}&dir={{.SortDir}}&q={{.Query}}&page={{sub .Page 1}}&size={{.PageSize}}&system={{.FilterSystem}}&severity={{.FilterSeverity}}&author={{.FilterAuthor}}&time={{.FilterTime}}"
        hx-target="#message-table">← Previous</a>
     {{end}}
     <span class="page-info">Page {{add .Page 1}} / {{.TotalPages}}</span>
     {{if .HasNext}}
-    <a href="#" hx-get="/messages?sort={{.SortBy}}&dir={{.SortDir}}&q={{.Query}}&page={{add .Page 1}}&size={{.PageSize}}"
+    <a href="#" hx-get="/messages?sort={{.SortBy}}&dir={{.SortDir}}&q={{.Query}}&page={{add .Page 1}}&size={{.PageSize}}&system={{.FilterSystem}}&severity={{.FilterSeverity}}&author={{.FilterAuthor}}&time={{.FilterTime}}"
        hx-target="#message-table">Next →</a>
     {{end}}
 </div>


### PR DESCRIPTION
## Summary
- Add dropdown filters for **System**, **Severity**, **Author** (populated from actual values)
- Add **time range** selector: last 1h, 6h, 24h, 7d, all
- All filters combine (AND logic) with sorting, pagination, and free-text search
- Show filtered count vs total (e.g. "42 / 10000 messages")
- Replace O(n²) insertion sort with `slices.SortFunc`
- Filter state preserved across pagination, column sorting, and 5s auto-refresh

## Test plan
- [x] All existing tests pass (updated for new `ListResult` return type)
- [x] 9 new tests: filter by system, severity, author, time, combined filters, query+filter, pagination with filters, distinct values

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)