### PR TITLE
fix: add catcherMode web to KCL deploy profile

### DIFF
--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -5,3 +5,4 @@ config.redisPort: "6379"
 config.redisStream: messages
 config.consumerGroup: homerun2-core-catcher
 config.redisPassword: changeme # pragma: allowlist secret
+config.catcherMode: web


### PR DESCRIPTION
## Summary
- Add `config.catcherMode: web` to the KCL deploy profile (`tests/kcl-deploy-profile.yaml`)
- Without this, the OCI kustomize artifact is rendered with the default `catcherMode: log`, so no Service, container port, or health probes are generated
- The deployed pod runs in web mode (via Flux env patch) but the missing Service causes empty responses from the HTTPRoute

## Test plan
- [x] `go test ./...` passes
- [x] `kcl` renders Service, container port, and probes with the updated profile
- [ ] Next OCI artifact push includes the Service manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)