### PR TITLE
feat: add version/build info to UI and clusterbook color scheme

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,9 @@ builds:
       - -s
       - -w
       - -extldflags=-static
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
     goos:
       - linux
       - darwin

--- a/internal/banner/banner.go
+++ b/internal/banner/banner.go
@@ -39,29 +39,29 @@ var mittArt = []string{
 const fieldWidth = 70
 
 var (
-	// Green gradient — catcher style
+	// Indigo gradient — clusterbook-inspired palette
 	greenHot = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#00CC66")).
+			Foreground(lipgloss.Color("#818cf8")).
 			Bold(true)
 
 	greenBright = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#00FF99")).
+			Foreground(lipgloss.Color("#a5b4fc")).
 			Bold(true)
 
 	dimGreen = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#005522"))
+			Foreground(lipgloss.Color("#312e81"))
 
-	// The "2" in a contrasting cyan
+	// The "2" in a contrasting orange accent
 	accentStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#00FFCC")).
+			Foreground(lipgloss.Color("#f97316")).
 			Bold(true)
 
 	serviceBlockStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#009966")).
+				Foreground(lipgloss.Color("#6366f1")).
 				Bold(true)
 
 	mittStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#FFFFFF")).
+			Foreground(lipgloss.Color("#f8fafc")).
 			Bold(true)
 )
 

--- a/internal/handlers/messages.go
+++ b/internal/handlers/messages.go
@@ -43,17 +43,17 @@ func init() {
 }
 
 // MessagesHandler serves the main dashboard page.
-func MessagesHandler(s *store.MessageStore) http.HandlerFunc {
+func MessagesHandler(s *store.MessageStore, info BuildInfo) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		data := buildTableData(s, r)
+		data := buildTableData(s, r, info)
 		templates.ExecuteTemplate(w, "index.html", data)
 	}
 }
 
 // MessagesTableHandler serves the HTMX partial for the message table.
-func MessagesTableHandler(s *store.MessageStore) http.HandlerFunc {
+func MessagesTableHandler(s *store.MessageStore, info BuildInfo) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		data := buildTableData(s, r)
+		data := buildTableData(s, r, info)
 		templates.ExecuteTemplate(w, "table.html", data)
 	}
 }
@@ -98,6 +98,10 @@ type tableData struct {
 	Systems    []string
 	Severities []string
 	Authors    []string
+	// Build info
+	Version string
+	Commit  string
+	Date    string
 }
 
 // parseSinceDuration converts a time filter string to a duration.
@@ -116,7 +120,7 @@ func parseSinceDuration(s string) time.Duration {
 	}
 }
 
-func buildTableData(s *store.MessageStore, r *http.Request) tableData {
+func buildTableData(s *store.MessageStore, r *http.Request, info BuildInfo) tableData {
 	q := r.URL.Query()
 
 	query := q.Get("q")
@@ -203,5 +207,8 @@ func buildTableData(s *store.MessageStore, r *http.Request) tableData {
 		Systems:        s.DistinctSystems(),
 		Severities:     s.DistinctSeverities(),
 		Authors:        s.DistinctAuthors(),
+		Version:        info.Version,
+		Commit:         info.Commit,
+		Date:           info.Date,
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -19,9 +19,17 @@ const (
 // refreshMsg triggers a UI refresh.
 type refreshMsg struct{}
 
+// BuildInfo holds version metadata for display.
+type BuildInfo struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
 // Model is the top-level Bubble Tea model.
 type Model struct {
 	store      *store.MessageStore
+	build      BuildInfo
 	view       int
 	table      tableModel
 	detail     detailModel
@@ -36,17 +44,18 @@ type Model struct {
 }
 
 // New creates a new TUI model.
-func New(s *store.MessageStore) Model {
+func New(s *store.MessageStore, info BuildInfo) Model {
 	return Model{
-		store:    s,
-		view:     viewList,
-		table:    newTable(),
-		detail:   newDetail(),
-		search:   newSearch(),
+		store:     s,
+		build:     info,
+		view:      viewList,
+		table:     newTable(),
+		detail:    newDetail(),
+		search:    newSearch(),
 		sortField: store.SortByTimestamp,
-		sortDir:  store.SortDesc,
-		page:     0,
-		pageSize: 20,
+		sortDir:   store.SortDesc,
+		page:      0,
+		pageSize:  20,
 	}
 }
 
@@ -194,9 +203,13 @@ func (m Model) View() tea.View {
 func (m Model) renderList() string {
 	var b strings.Builder
 
-	// Header
+	// Title block (bigger header)
+	titleLine := titleStyle.Width(m.width).Render("  HOMERUN² core-catcher")
+	b.WriteString(titleLine + "\n")
+
+	// Keybindings bar
 	header := headerStyle.Width(m.width).Render(
-		fmt.Sprintf("  HOMERUN² core-catcher    [/] search  [s] sort  [S] dir  [n/p] page  [enter] detail  [q] quit"),
+		"  [/] search  [s] sort  [S] dir  [n/p] page  [enter] detail  [q] quit",
 	)
 	b.WriteString(header + "\n")
 
@@ -216,17 +229,23 @@ func (m Model) renderList() string {
 	b.WriteString(sortInfoStyle.Render(fmt.Sprintf("  sort: %s %s", sortNames[m.sortField], dirName)) + "\n")
 
 	// Table
-	tableHeight := m.height - 7
+	tableHeight := m.height - 9
 	if m.searching || m.search.query != "" {
 		tableHeight--
 	}
 	b.WriteString(m.table.Render(m.width, tableHeight))
 
-	// Footer
+	// Footer with version info
 	total := m.store.Count()
 	totalPages := m.totalPages()
+	commitShort := m.build.Commit
+	if len(commitShort) > 7 {
+		commitShort = commitShort[:7]
+	}
 	footer := footerStyle.Width(m.width).Render(
-		fmt.Sprintf("  %d messages | page %d/%d | stream: messages", total, m.page+1, max(totalPages, 1)),
+		fmt.Sprintf("  %d messages | page %d/%d | v%s | %s | %s",
+			total, m.page+1, max(totalPages, 1),
+			m.build.Version, commitShort, m.build.Date),
 	)
 	b.WriteString("\n" + footer)
 
@@ -267,20 +286,26 @@ func (m Model) totalPages() int {
 	return (total + m.pageSize - 1) / m.pageSize
 }
 
-// Styles
+// Styles — indigo/navy palette inspired by clusterbook
 var (
+	titleStyle = lipgloss.NewStyle().
+		Background(lipgloss.Color("#4f46e5")).
+		Foreground(lipgloss.Color("#f8fafc")).
+		Bold(true).
+		Padding(0, 1)
+
 	headerStyle = lipgloss.NewStyle().
-		Background(lipgloss.Color("#00CC66")).
-		Foreground(lipgloss.Color("#000000")).
+		Background(lipgloss.Color("#1e293b")).
+		Foreground(lipgloss.Color("#94a3b8")).
 		Bold(true)
 
 	footerStyle = lipgloss.NewStyle().
-		Background(lipgloss.Color("#333333")).
-		Foreground(lipgloss.Color("#CCCCCC"))
+		Background(lipgloss.Color("#1e293b")).
+		Foreground(lipgloss.Color("#64748b"))
 
 	sortInfoStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#888888"))
+		Foreground(lipgloss.Color("#64748b"))
 
 	searchActiveStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#FFAA00"))
+		Foreground(lipgloss.Color("#f97316"))
 )

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -58,9 +58,9 @@ func (d detailModel) Render(width int) string {
 
 var (
 	detailLabelStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#00CC66")).
+		Foreground(lipgloss.Color("#818cf8")).
 		Bold(true)
 
 	detailValueStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#FFFFFF"))
+		Foreground(lipgloss.Color("#e2e8f0"))
 )

--- a/internal/tui/search.go
+++ b/internal/tui/search.go
@@ -39,5 +39,5 @@ func (s searchModel) View() string {
 }
 
 var searchStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("#FFAA00")).
+	Foreground(lipgloss.Color("#f97316")).
 	Bold(true)

--- a/internal/tui/table.go
+++ b/internal/tui/table.go
@@ -102,30 +102,30 @@ func applySeverityColor(row, severity string, base lipgloss.Style) string {
 	case "error":
 		return base.Foreground(lipgloss.Color("#FF4444")).Render(row)
 	case "warning":
-		return base.Foreground(lipgloss.Color("#FFAA00")).Render(row)
+		return base.Foreground(lipgloss.Color("#f97316")).Render(row)
 	case "success":
-		return base.Foreground(lipgloss.Color("#00CC66")).Render(row)
+		return base.Foreground(lipgloss.Color("#4ade80")).Render(row)
 	case "debug":
-		return base.Foreground(lipgloss.Color("#888888")).Render(row)
+		return base.Foreground(lipgloss.Color("#64748b")).Render(row)
 	default:
-		return base.Render(row)
+		return base.Foreground(lipgloss.Color("#e2e8f0")).Render(row)
 	}
 }
 
 var (
 	tableHeaderStyle = lipgloss.NewStyle().
 		Bold(true).
-		Foreground(lipgloss.Color("#00CC66")).
-		Background(lipgloss.Color("#1A1A1A"))
+		Foreground(lipgloss.Color("#818cf8")).
+		Background(lipgloss.Color("#0f172a"))
 
 	rowStyle = lipgloss.NewStyle()
 
 	selectedRowStyle = lipgloss.NewStyle().
-		Background(lipgloss.Color("#004422")).
-		Foreground(lipgloss.Color("#FFFFFF")).
+		Background(lipgloss.Color("#4f46e5")).
+		Foreground(lipgloss.Color("#f8fafc")).
 		Bold(true)
 
 	emptyStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#666666")).
+		Foreground(lipgloss.Color("#475569")).
 		Italic(true)
 )

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -6,35 +6,47 @@
     <title>HOMERUN² core-catcher</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <script src="/static/htmx.min.js"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <style>
         :root { --pico-font-size: 14px; }
+        body { background: #0f172a; }
         .severity-error { color: #ff4444; font-weight: bold; }
-        .severity-warning { color: #ffaa00; font-weight: bold; }
-        .severity-success { color: #00cc66; font-weight: bold; }
-        .severity-info { color: #4488ff; }
-        .severity-debug { color: #888888; }
-        .header-bar { background: #00cc66; color: #000; padding: 0.8rem 1.5rem; margin-bottom: 1rem; display: flex; justify-content: space-between; align-items: center; }
-        .header-bar h1 { margin: 0; font-size: 1.4rem; }
+        .severity-warning { color: #f97316; font-weight: bold; }
+        .severity-success { color: #4ade80; font-weight: bold; }
+        .severity-info { color: #60a5fa; }
+        .severity-debug { color: #64748b; }
+        .header-bar { background: #4f46e5; color: #f8fafc; padding: 1.2rem 1.5rem; margin-bottom: 1rem; display: flex; justify-content: space-between; align-items: center; }
+        .header-bar h1 { margin: 0; font-family: 'Press Start 2P', cursive; font-size: 1.6rem; color: #f8fafc; letter-spacing: 0.08em; text-shadow: 3px 3px 0px #312e81; }
+        .header-bar .subtitle { font-family: 'Press Start 2P', cursive; font-size: 0.55rem; color: #f97316; margin-top: 0.4rem; letter-spacing: 0.12em; text-transform: uppercase; }
         .header-bar .actions { display: flex; gap: 0.5rem; }
-        .header-bar a { color: #000; font-size: 0.85rem; }
+        .header-bar a { color: #e2e8f0; font-size: 0.85rem; }
+        .header-bar a:hover { color: #f8fafc; }
         table { font-size: 0.85rem; }
+        thead th { background: #1e293b; color: #818cf8; }
         .clickable { cursor: pointer; }
-        .clickable:hover { background: rgba(0,204,102,0.1); }
-        .detail-panel { background: var(--pico-card-background-color); border: 1px solid var(--pico-muted-border-color); padding: 1.5rem; border-radius: 0.5rem; margin-bottom: 1rem; }
-        .detail-panel dt { color: #00cc66; font-weight: bold; }
-        .detail-panel dd { margin-bottom: 0.5rem; margin-left: 0; }
+        .clickable:hover { background: rgba(99,102,241,0.15); }
+        .detail-panel { background: #1e293b; border: 1px solid #334155; padding: 1.5rem; border-radius: 0.5rem; margin-bottom: 1rem; }
+        .detail-panel dt { color: #818cf8; font-weight: bold; }
+        .detail-panel dd { margin-bottom: 0.5rem; margin-left: 0; color: #e2e8f0; }
         .controls { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; margin-bottom: 1rem; }
         .controls input[type="search"] { max-width: 250px; margin: 0; }
         .controls select { max-width: 180px; margin: 0; padding: 0.4rem 0.6rem; font-size: 0.85rem; }
         .page-info { color: var(--pico-muted-color); font-size: 0.85rem; }
         .pagination { display: flex; gap: 0.5rem; align-items: center; }
+        .pagination a { color: #818cf8; }
         .filter-count { font-size: 0.85rem; color: var(--pico-muted-color); }
-        .filter-count strong { color: #00cc66; }
+        .filter-count strong { color: #818cf8; }
+        .build-footer { background: #1e293b; color: #475569; padding: 0.6rem 1.5rem; margin-top: 1rem; display: flex; gap: 1.5rem; font-size: 0.75rem; border-top: 1px solid #334155; }
+        .build-footer .label { color: #64748b; }
+        .build-footer .value { color: #818cf8; }
     </style>
 </head>
 <body>
     <div class="header-bar">
-        <h1>HOMERUN² core-catcher</h1>
+        <div>
+            <h1>HOMERUN² core-catcher</h1>
+            <div class="subtitle">message stream dashboard</div>
+        </div>
         <div class="actions">
             <a href="/export?format=json">Export JSON</a>
             <a href="/export?format=csv">Export CSV</a>
@@ -108,5 +120,10 @@
             {{template "table.html" .}}
         </div>
     </main>
+    <div class="build-footer">
+        <div><span class="label">version</span> <span class="value">{{.Version}}</span></div>
+        <div><span class="label">commit</span> <span class="value">{{if gt (len .Commit) 7}}{{slice .Commit 0 7}}{{else}}{{.Commit}}{{end}}</span></div>
+        <div><span class="label">built</span> <span class="value">{{.Date}}</span></div>
+    </div>
 </body>
 </html>

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 			}()
 		}
 
-		p := tea.NewProgram(tui.New(msgStore))
+		p := tea.NewProgram(tui.New(msgStore, tui.BuildInfo{Version: version, Commit: commit, Date: date}))
 		if _, err := p.Run(); err != nil {
 			fmt.Fprintf(os.Stderr, "TUI error: %v\n", err)
 			os.Exit(1)
@@ -141,8 +141,8 @@ func main() {
 		buildInfo := handlers.BuildInfo{Version: version, Commit: commit, Date: date}
 
 		mux := http.NewServeMux()
-		mux.HandleFunc("/", handlers.MessagesHandler(msgStore))
-		mux.HandleFunc("/messages", handlers.MessagesTableHandler(msgStore))
+		mux.HandleFunc("/", handlers.MessagesHandler(msgStore, buildInfo))
+		mux.HandleFunc("/messages", handlers.MessagesTableHandler(msgStore, buildInfo))
 		mux.HandleFunc("/messages/", handlers.MessageDetailHandler(msgStore))
 		mux.HandleFunc("/export", handlers.ExportHandler(msgStore))
 		mux.HandleFunc("/health", handlers.NewHealthHandler(buildInfo))


### PR DESCRIPTION
## Summary
- Display version, git commit, and build date in both TUI footer and web dashboard footer (matching clusterbook's approach)
- Adopt clusterbook-inspired indigo/navy color scheme across TUI (banner, header, table, detail, search) and web UI
- Make header/logo bigger: two-line title+keybindings in TUI, Press Start 2P retro font in web
- Add missing goreleaser ldflags for version/commit/date injection in binary releases

## Test plan
- [ ] Run `CATCHER_MODE=cli CATCHER_BACKEND=file CATCHER_FILE_PATH=tests/smoke-test-messages.json go run .` and verify indigo color scheme + version in footer
- [ ] Run `CATCHER_MODE=web CATCHER_BACKEND=file go run .` and verify web dashboard header, colors, and version footer
- [ ] Verify `go test ./...` passes
- [ ] Verify container build injects version via ko ldflags

🤖 Generated with [Claude Code](https://claude.com/claude-code)