### PR TITLE
feat: web UI polish, build date fix, and local dev tasks

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -9,4 +9,4 @@ builds:
       - -w
       - -X main.version={{ if index .Env "VERSION" }}{{.Env.VERSION}}{{ else }}dev{{ end }}
       - -X main.commit={{ if index .Env "COMMIT" }}{{.Env.COMMIT}}{{ else }}unknown{{ end }}
-      - -X main.date={{ if index .Env "DATE" }}{{.Env.DATE}}{{ else }}unknown{{ end }}
+      - -X main.date={{ if index .Env "BUILD_DATE" }}{{.Env.BUILD_DATE}}{{ else }}{{ if index .Env "DATE" }}{{.Env.DATE}}{{ else }}unknown{{ end }}{{ end }}

--- a/README.md
+++ b/README.md
@@ -129,6 +129,34 @@ Taskfile.yaml              # Task runner
 
 </details>
 
+## Local Development
+
+<details>
+<summary><b>Run web UI with file backend</b></summary>
+
+```bash
+# Run web dashboard with sample messages (default port 8080)
+task run-web
+
+# Custom file and port
+task run-web FILE_PATH=tests/integration-test-messages.json PORT=9090
+```
+
+</details>
+
+<details>
+<summary><b>Run CLI TUI with file backend</b></summary>
+
+```bash
+# Run interactive TUI with sample messages
+task run-cli
+
+# Custom file
+task run-cli FILE_PATH=tests/integration-test-messages.json
+```
+
+</details>
+
 ## Testing
 
 <details>

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -155,6 +155,32 @@ tasks:
         echo "Run: https://github.com/{{ .ORGA_NAME }}/{{ .PROJECT }}/actions/runs/${RUN_ID}"
         gh run watch "${RUN_ID}"
 
+  # === Local Dev ===
+
+  run-web:
+    desc: Run web UI with file backend (local dev)
+    vars:
+      FILE_PATH: '{{ .FILE_PATH | default "tests/integration-test-messages.json" }}'
+      PORT: '{{ .PORT | default "8080" }}'
+    env:
+      CATCHER_MODE: web
+      CATCHER_BACKEND: file
+      CATCHER_FILE_PATH: "{{ .FILE_PATH }}"
+      PORT: "{{ .PORT }}"
+    cmds:
+      - go run .
+
+  run-cli:
+    desc: Run CLI TUI with file backend (local dev)
+    vars:
+      FILE_PATH: '{{ .FILE_PATH | default "tests/integration-test-messages.json" }}'
+    env:
+      CATCHER_MODE: cli
+      CATCHER_BACKEND: file
+      CATCHER_FILE_PATH: "{{ .FILE_PATH }}"
+    cmds:
+      - go run .
+
   # === Redis (Development) ===
 
   run-redis-cli:

--- a/internal/web/templates/detail.html
+++ b/internal/web/templates/detail.html
@@ -7,7 +7,7 @@
     <dl>
         <dt>Object ID</dt><dd>{{.ObjectID}}</dd>
         <dt>Stream ID</dt><dd>{{.StreamID}}</dd>
-        <dt>Severity</dt><dd><span class="{{severityClass .Severity}}">{{.Severity}}</span></dd>
+        <dt>Severity</dt><dd><span class="{{severityClass .Severity}}" style="text-transform:uppercase">{{.Severity}}</span></dd>
         <dt>Message</dt><dd>{{.Message.Message}}</dd>
         <dt>Author</dt><dd>{{.Author}}</dd>
         <dt>System</dt><dd>{{.System}}</dd>

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>HOMERUN² core-catcher</title>
+    <title>HOMERUN²</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <script src="/static/htmx.min.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
@@ -13,16 +13,16 @@
         .severity-error { color: #ff4444; font-weight: bold; }
         .severity-warning { color: #f97316; font-weight: bold; }
         .severity-success { color: #4ade80; font-weight: bold; }
-        .severity-info { color: #60a5fa; }
+        .severity-info { color: #60a5fa; font-weight: bold; }
         .severity-debug { color: #64748b; }
-        .header-bar { background: #4f46e5; color: #f8fafc; padding: 1.2rem 1.5rem; margin-bottom: 1rem; display: flex; justify-content: space-between; align-items: center; }
-        .header-bar h1 { margin: 0; font-family: 'Press Start 2P', cursive; font-size: 1.6rem; color: #f8fafc; letter-spacing: 0.08em; text-shadow: 3px 3px 0px #312e81; }
-        .header-bar .subtitle { font-family: 'Press Start 2P', cursive; font-size: 0.55rem; color: #f97316; margin-top: 0.4rem; letter-spacing: 0.12em; text-transform: uppercase; }
+        .header-bar { background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 50%, #a855f7 100%); color: #f8fafc; padding: 1.8rem 1.5rem; margin-bottom: 1rem; display: flex; justify-content: space-between; align-items: flex-end; border-bottom: 3px solid #f97316; }
+        .header-bar h1 { margin: 0; font-family: 'Press Start 2P', cursive; font-size: 2.2rem; color: #ffffff; letter-spacing: 0.08em; text-shadow: 3px 3px 0px rgba(0,0,0,0.3); }
+        .header-bar .subtitle { font-family: 'Press Start 2P', cursive; font-size: 0.7rem; color: #fbbf24; margin-top: 0.5rem; letter-spacing: 0.12em; text-transform: uppercase; }
         .header-bar .actions { display: flex; gap: 0.5rem; }
         .header-bar a { color: #e2e8f0; font-size: 0.85rem; }
         .header-bar a:hover { color: #f8fafc; }
         table { font-size: 0.85rem; }
-        thead th { background: #1e293b; color: #818cf8; }
+        thead th { background: #1e293b; color: #818cf8; text-transform: uppercase; }
         .clickable { cursor: pointer; }
         .clickable:hover { background: rgba(99,102,241,0.15); }
         .detail-panel { background: #1e293b; border: 1px solid #334155; padding: 1.5rem; border-radius: 0.5rem; margin-bottom: 1rem; }
@@ -44,7 +44,7 @@
 <body>
     <div class="header-bar">
         <div>
-            <h1>HOMERUN² core-catcher</h1>
+            <h1>HOMERUN²</h1>
             <div class="subtitle">message stream dashboard</div>
         </div>
         <div class="actions">
@@ -111,7 +111,6 @@
             <input type="hidden" name="dir" class="filter-control" value="{{.SortDir}}">
             <input type="hidden" name="size" class="filter-control" value="{{.PageSize}}">
 
-            <span class="filter-count"><strong>{{.Total}}</strong> / {{.TotalAll}} messages</span>
         </div>
 
         <div id="message-detail"></div>
@@ -121,9 +120,12 @@
         </div>
     </main>
     <div class="build-footer">
-        <div><span class="label">version</span> <span class="value">{{.Version}}</span></div>
-        <div><span class="label">commit</span> <span class="value">{{if gt (len .Commit) 7}}{{slice .Commit 0 7}}{{else}}{{.Commit}}{{end}}</span></div>
-        <div><span class="label">built</span> <span class="value">{{.Date}}</span></div>
+        <div style="display:flex;gap:1.5rem">
+            <div><span class="label">version</span> <span class="value">{{.Version}}</span></div>
+            <div><span class="label">commit</span> <span class="value">{{if gt (len .Commit) 7}}{{slice .Commit 0 7}}{{else}}{{.Commit}}{{end}}</span></div>
+            <div><span class="label">built</span> <span class="value">{{.Date}}</span></div>
+        </div>
+        <div style="margin-left:auto;display:flex;align-items:center;gap:0.5rem"><span class="label">a</span> <a href="https://github.com/stuttgart-things" target="_blank" style="color:#818cf8;text-decoration:none">stuttgart-things</a> <span class="label">project</span> <img src="https://raw.githubusercontent.com/stuttgart-things/docs/main/hugo/sthings-logo.png" alt="sthings" style="height:24px;"></div>
     </div>
 </body>
 </html>

--- a/internal/web/templates/table.html
+++ b/internal/web/templates/table.html
@@ -34,7 +34,7 @@
             hx-target="#message-detail"
             hx-swap="innerHTML">
             <td>{{.Title}}</td>
-            <td><span class="{{severityClass .Severity}}">{{.Severity}}</span></td>
+            <td><span class="{{severityClass .Severity}}" style="text-transform:uppercase">{{.Severity}}</span></td>
             <td>{{.System}}</td>
             <td>{{.Author}}</td>
             <td>{{.CaughtAt.Format "2006-01-02 15:04:05"}}</td>
@@ -46,6 +46,7 @@
 </table>
 
 <div class="pagination">
+    <span class="filter-count"><strong>{{.Total}}</strong> / {{.TotalAll}} messages</span>
     {{if .HasPrev}}
     <a href="#" hx-get="/messages?sort={{.SortBy}}&dir={{.SortDir}}&q={{.Query}}&page={{sub .Page 1}}&size={{.PageSize}}&system={{.FilterSystem}}&severity={{.FilterSeverity}}&author={{.FilterAuthor}}&time={{.FilterTime}}"
        hx-target="#message-table">← Previous</a>


### PR DESCRIPTION
## Summary
- Polish web UI: bigger header, poppy gradient, uppercase severity labels with colors, filter count updates with search
- Fix ko build date: use BUILD_DATE env var to match reusable workflow
- Add `task run-web` and `task run-cli` for local dev with file backend
- Add Local Development section to README

## Test plan
- [ ] `task run-web` starts web dashboard with sample messages
- [ ] Severity labels show colored and uppercase (INFO blue, ERROR red, SUCCESS green)
- [ ] Search filter count updates correctly (e.g. 1/5 when filtering)
- [ ] Footer shows "a stuttgart-things project" with logo on right, version info on left
- [ ] Container build injects build date via BUILD_DATE env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)