### PR TITLE
fix: hydrate in-memory store from RedisJSON on startup

### DIFF
--- a/internal/catcher/catcher.go
+++ b/internal/catcher/catcher.go
@@ -24,6 +24,11 @@ type Catcher interface {
 	Errors() <-chan error
 }
 
+// Hydrator is an optional interface for catchers that can pre-load existing messages into the store.
+type Hydrator interface {
+	HydrateStore(ctx context.Context) (int, error)
+}
+
 // RedisCatcher consumes messages from Redis Streams and resolves full payloads from Redis JSON.
 type RedisCatcher struct {
 	consumer    *redisqueue.Consumer
@@ -125,6 +130,57 @@ func (c *RedisCatcher) handleMessage(msg *redisqueue.Message) error {
 	}
 
 	return nil
+}
+
+// HydrateStore scans existing RedisJSON documents and loads them into the store
+// via the configured handlers. This populates the in-memory store on startup so
+// that web/cli modes show existing messages immediately, independent of consumer
+// group state.
+func (c *RedisCatcher) HydrateStore(ctx context.Context) (int, error) {
+	var cursor uint64
+	var loaded int
+
+	for {
+		keys, nextCursor, err := c.redisClient.Scan(ctx, cursor, "*", 100).Result()
+		if err != nil {
+			return loaded, fmt.Errorf("SCAN: %w", err)
+		}
+
+		for _, key := range keys {
+			// Skip non-JSON keys by attempting JSON.GET
+			result, err := c.redisClient.Do(ctx, "JSON.GET", key, ".").Text()
+			if err != nil {
+				// Not a JSON key or other error — skip
+				continue
+			}
+
+			var msg homerun.Message
+			if err := json.Unmarshal([]byte(result), &msg); err != nil {
+				slog.Warn("hydrate: failed to unmarshal JSON key", "key", key, "error", err)
+				continue
+			}
+
+			caught := models.CaughtMessage{
+				Message:  msg,
+				ObjectID: key,
+				StreamID: "hydrated",
+				CaughtAt: time.Now(),
+			}
+
+			for _, h := range c.handlers {
+				h(caught)
+			}
+			loaded++
+		}
+
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+
+	slog.Info("hydration complete", "loaded", loaded)
+	return loaded, nil
 }
 
 // resolveMessage fetches the full message payload from Redis JSON using JSON.GET.

--- a/internal/catcher/catcher_test.go
+++ b/internal/catcher/catcher_test.go
@@ -1,0 +1,18 @@
+package catcher
+
+import (
+	"testing"
+)
+
+func TestRedisCatcherImplementsHydrator(t *testing.T) {
+	// Verify RedisCatcher satisfies the Hydrator interface at compile time.
+	var _ Hydrator = (*RedisCatcher)(nil)
+}
+
+func TestFileCatcherDoesNotImplementHydrator(t *testing.T) {
+	// FileCatcher should NOT implement Hydrator — hydration is Redis-only.
+	var c Catcher = NewFileCatcher("dummy.json", 0)
+	if _, ok := c.(Hydrator); ok {
+		t.Fatal("FileCatcher should not implement Hydrator")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -104,6 +104,20 @@ func main() {
 		)
 	}
 
+	// Hydrate store from existing RedisJSON documents before starting servers
+	if msgStore != nil {
+		if h, ok := c.(catcher.Hydrator); ok {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			loaded, err := h.HydrateStore(ctx)
+			cancel()
+			if err != nil {
+				slog.Warn("store hydration failed", "error", err, "loaded", loaded)
+			} else {
+				slog.Info("store hydrated from existing Redis documents", "loaded", loaded)
+			}
+		}
+	}
+
 	switch mode {
 	case "cli":
 		// Run catcher in background, TUI in foreground


### PR DESCRIPTION
## Summary
- Adds `Hydrator` interface and `HydrateStore` method to `RedisCatcher` that scans existing RedisJSON documents via `SCAN` + `JSON.GET` and loads them into the `MessageStore` on startup
- Calls hydration in `main.go` before starting web/cli servers (with 30s timeout), so the UI shows existing messages immediately after pod restart
- Adds compile-time interface verification tests

## Root Cause
In `web` mode, the `MessageStore` is purely in-memory. On pod restart, the `redisqueue` consumer group has already ACK'd all previous stream entries, so `XREADGROUP` only delivers new messages — the UI showed "0 / 0 messages" despite 111 RedisJSON documents being present.

## Changes
- `internal/catcher/catcher.go`: Added `Hydrator` interface and `RedisCatcher.HydrateStore()` method
- `internal/catcher/catcher_test.go`: Interface verification tests
- `main.go`: Hydration call before server startup (cli/web modes with redis backend)

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes
- [ ] Deploy to staging, restart pod, verify UI shows existing messages
- [ ] Verify new messages still appear via stream consumer after hydration

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)