### PR TITLE
feat: multi-stream subscription (list of Redis streams)

### DIFF
--- a/internal/catcher/catcher.go
+++ b/internal/catcher/catcher.go
@@ -29,16 +29,26 @@ type Hydrator interface {
 	HydrateStore(ctx context.Context) (int, error)
 }
 
-// RedisCatcher consumes messages from Redis Streams and resolves full payloads from Redis JSON.
+// RedisCatcher consumes messages from one or more Redis Streams and resolves
+// full payloads from Redis JSON.
 type RedisCatcher struct {
 	consumer    *redisqueue.Consumer
 	redisClient *redis.Client
-	stream      string
+	streams     []string
 	handlers    []MessageHandler
 }
 
-// NewRedisCatcher creates a consumer connected to the given Redis stream.
-func NewRedisCatcher(rc homerun.RedisConfig, groupName, consumerName string, handlers ...MessageHandler) (*RedisCatcher, error) {
+// NewRedisCatcher creates a consumer connected to the given Redis streams.
+// If streams is empty, it falls back to rc.Stream (legacy single-stream mode).
+// A single-element list behaves identically to the legacy configuration.
+func NewRedisCatcher(rc homerun.RedisConfig, streams []string, groupName, consumerName string, handlers ...MessageHandler) (*RedisCatcher, error) {
+	if len(streams) == 0 {
+		if rc.Stream == "" {
+			return nil, fmt.Errorf("no streams configured: pass streams or set rc.Stream")
+		}
+		streams = []string{rc.Stream}
+	}
+
 	if consumerName == "" {
 		hostname, _ := os.Hostname()
 		consumerName = hostname
@@ -68,13 +78,20 @@ func NewRedisCatcher(rc homerun.RedisConfig, groupName, consumerName string, han
 	c := &RedisCatcher{
 		consumer:    consumer,
 		redisClient: redisClient,
-		stream:      rc.Stream,
+		streams:     streams,
 		handlers:    handlers,
 	}
 
-	consumer.Register(rc.Stream, c.handleMessage)
+	for _, stream := range streams {
+		consumer.Register(stream, c.handleMessage)
+	}
 
 	return c, nil
+}
+
+// Streams returns the list of streams this catcher is subscribed to.
+func (c *RedisCatcher) Streams() []string {
+	return c.streams
 }
 
 // Run starts the consumer. Blocks until Shutdown is called.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,38 @@ func LoadRedisConfig() homerun.RedisConfig {
 	}
 }
 
+// LoadStreams returns the list of Redis streams the catcher should subscribe to.
+//
+// Resolution:
+//  1. REDIS_STREAMS (comma-separated) — preferred, enables multi-stream subscription
+//  2. REDIS_STREAM — legacy single-stream env var, wrapped in a one-element list
+//  3. ["messages"] — hardcoded default
+//
+// Legacy single-stream deployments keep working unchanged.
+func LoadStreams() []string {
+	return ParseStreams(os.Getenv("REDIS_STREAMS"), os.Getenv("REDIS_STREAM"))
+}
+
+// ParseStreams is the pure resolution helper behind LoadStreams. Exposed for tests.
+func ParseStreams(streamsEnv, streamFallback string) []string {
+	if streamsEnv != "" {
+		parts := strings.Split(streamsEnv, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if s := strings.TrimSpace(p); s != "" {
+				out = append(out, s)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	if streamFallback != "" {
+		return []string{streamFallback}
+	}
+	return []string{"messages"}
+}
+
 // SetupLogging configures slog as the default logger based on LOG_FORMAT and LOG_LEVEL env vars.
 func SetupLogging() {
 	format := strings.ToLower(homerun.GetEnv("LOG_FORMAT", "json"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseStreams(t *testing.T) {
+	cases := []struct {
+		name        string
+		streamsEnv  string
+		streamFall  string
+		want        []string
+	}{
+		{"multi from REDIS_STREAMS", "homerun,releases", "ignored", []string{"homerun", "releases"}},
+		{"whitespace trimmed", " homerun , releases ", "", []string{"homerun", "releases"}},
+		{"empty entries dropped", "homerun,,releases,", "", []string{"homerun", "releases"}},
+		{"legacy REDIS_STREAM single", "", "homerun", []string{"homerun"}},
+		{"empty streams env falls back to legacy", "", "messages", []string{"messages"}},
+		{"both unset returns hardcoded default", "", "", []string{"messages"}},
+		{"streams with only whitespace falls back to legacy", " , , ", "legacy", []string{"legacy"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseStreams(tc.streamsEnv, tc.streamFall)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParseStreams(%q, %q) = %v, want %v", tc.streamsEnv, tc.streamFall, got, tc.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -85,11 +85,12 @@ func main() {
 		)
 	default:
 		redisConfig := config.LoadRedisConfig()
+		streams := config.LoadStreams()
 		consumerGroup := homerun.GetEnv("CONSUMER_GROUP", "homerun2-core-catcher")
 		consumerName := homerun.GetEnv("CONSUMER_NAME", "")
 
 		var err error
-		c, err = catcher.NewRedisCatcher(redisConfig, consumerGroup, consumerName, msgHandlers...)
+		c, err = catcher.NewRedisCatcher(redisConfig, streams, consumerGroup, consumerName, msgHandlers...)
 		if err != nil {
 			slog.Error("failed to create catcher", "error", err)
 			os.Exit(1)
@@ -98,7 +99,7 @@ func main() {
 			"backend", "redis",
 			"redis_addr", redisConfig.Addr,
 			"redis_port", redisConfig.Port,
-			"stream", redisConfig.Stream,
+			"streams", streams,
 			"consumer_group", consumerGroup,
 			"mode", mode,
 		)


### PR DESCRIPTION
## Summary
- Add \`REDIS_STREAMS\` (comma-separated) env var; catcher subscribes to every listed stream via per-stream \`consumer.Register\` calls.
- Legacy \`REDIS_STREAM\` still honored and resolves to a one-element list — existing deployments behave identically.
- \`NewRedisCatcher\` takes an explicit \`streams []string\` arg; startup log emits the resolved list under \`streams\`.

### Config shape note

The upstream issue proposed a YAML config shape, but core-catcher is env-var driven (see CLAUDE.md). The spirit of the proposal is preserved: a list of streams with legacy single-stream fallback. \`REDIS_STREAMS=homerun,releases\` is the new knob; omitting it keeps today's behavior.

## Resolution order

1. \`REDIS_STREAMS\` (comma-separated, whitespace-trimmed, empty entries dropped)
2. \`REDIS_STREAM\` (legacy single-stream env var)
3. \`[\"messages\"]\` hardcoded default

Closes #52
Refs stuttgart-things/homerun-library#83

## Test plan
- [x] \`go test ./internal/...\` green (new \`TestParseStreams\` covers multi, legacy, whitespace, empty-entry, default-fallback)
- [x] \`go build .\` clean
- [ ] CI: build / lint / image
- [ ] Manual: run with \`REDIS_STREAMS=homerun,releases\` and confirm startup log shows both; verify unset \`REDIS_STREAMS\` still subscribes to \`REDIS_STREAM\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)