### PR TITLE
feat(ci): PR-preview workflows (build-pr + kustomize + cleanup + bot)

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -14,7 +14,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-pr:
+    if: github.event_name == 'pull_request'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      registry: ghcr.io
+      tags: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }},pr-${{ github.event.number }}
+    secrets: inherit # pragma: allowlist secret
+
+  build-main:
+    if: github.event_name != 'pull_request'
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
     with:
       runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-pr-artifacts.yaml
+++ b/.github/workflows/cleanup-pr-artifacts.yaml
@@ -1,0 +1,16 @@
+---
+name: Cleanup PR Artifacts
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  cleanup:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-cleanup-pr-artifacts.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      packages: homerun2-core-catcher,homerun2-core-catcher-kustomize
+      dry-run: false
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/comment-preview-url.yaml
+++ b/.github/workflows/comment-preview-url.yaml
@@ -1,0 +1,59 @@
+---
+name: Comment Preview URL on PR
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const num = context.issue.number;
+            const url = `https://cc-pr-${num}.homerun2-dev.sthings-vsphere.labul.sva.de`;
+            const ns  = `homerun2-core-catcher-pr-${num}`;
+            const marker = "<!-- preview-url-bot -->";
+            const body = [
+              marker,
+              "## 🚀 Preview environment",
+              "",
+              `| | |`,
+              `|--|--|`,
+              `| URL | ${url} |`,
+              `| Namespace | \`${ns}\` on \`homerun2-dev\` |`,
+              `| ArgoCD | [\`${ns}\`](https://argocd.platform.sthings-vsphere.labul.sva.de/applications?search=${ns}) |`,
+              "",
+              "Spinning up — give it a couple of minutes for image + kustomize OCI builds to publish and for ArgoCD to sync.",
+              "core-catcher's preview ships with omni-pitcher + redis-stack co-tenanted in the same namespace; a seed Job posts a fixture to /pitch so the dashboard is non-empty when you load it.",
+              "Closing this PR tears the preview down automatically.",
+            ].join("\n");
+
+            // Sticky comment: update on reopen instead of stacking duplicates.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: num,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: num,
+                body,
+              });
+            }

--- a/.github/workflows/push-kustomize-pr.yaml
+++ b/.github/workflows/push-kustomize-pr.yaml
@@ -1,0 +1,21 @@
+---
+name: Push PR Kustomize OCI
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  push-kustomize:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-push-kustomize.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-deploy-profile.yaml
+      kustomize-oci-repo: ghcr.io/stuttgart-things/homerun2-core-catcher-kustomize
+      tag: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+    secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Mirrors the workflow set shipped by `homerun2-omni-pitcher` for its per-PR preview environments. Same reusable-workflow callers, same artifact tag scheme (`pr-<num>-<sha>`), same bot-comment pattern.

| Workflow | Purpose |
|---|---|
| `build-scan-image.yaml` | adds `build-pr` job pushing to `ghcr.io/stuttgart-things/homerun2-core-catcher:pr-<num>-<sha>` (+ moving `pr-<num>` tag) on PR push; `build-main` job for `push: main` unchanged |
| `push-kustomize-pr.yaml` | pushes the matching kustomize OCI artifact to `ghcr.io/stuttgart-things/homerun2-core-catcher-kustomize:pr-<num>-<sha>` |
| `cleanup-pr-artifacts.yaml` | deletes both packages' `pr-<num>-*` versions on PR close (`dry-run: false`) |
| `comment-preview-url.yaml` | sticky bot comment on PR open/reopen with: URL `cc-pr-<num>.homerun2-dev.sthings-vsphere.labul.sva.de`, namespace `homerun2-core-catcher-pr-<num>`, ArgoCD link |

## Per stuttgart-things/homerun2-omni-pitcher#116

First component rollout after the pilot. Decisions locked in:
- **Namespace**: `homerun2-core-catcher-pr-<num>` (mirrors image name)
- **Hostname**: `cc-pr-<num>.homerun2-dev....` (shortened convention matching `omni-pr-<num>`)
- **Preview contents**: core-catcher + omni-pitcher + redis-stack (full chain, dev-experience parity)

## Cluster-side wiring (separate PR on stuttgart-things)

After this lands, a stuttgart-things PR adds:

- `core-catcher-pr-preview-appset.yaml` — AppSet with PR generator pointed at this repo
- 4 new policy Applications (`homerun2-core-catcher-preview-{quota,secrets,seed-data,sweep}.yaml`) — same catalog charts as omni-pitcher's, deployed with `namespacePrefix: "homerun2-core-catcher-pr-*"` and Secret names adjusted

## Test plan

- [x] Workflows YAML-valid
- [x] Artifact paths point at `homerun2-core-catcher` (image) + `homerun2-core-catcher-kustomize` (kustomize OCI)
- [x] Bot URL matches the AppSet's planned `coreCatcher.hostname` shape
- [ ] After merge + cluster-side PR: open a no-op PR on this repo → bot comments → CI publishes artifacts → AppSet picks up → preview env spins up