### PR TITLE
chore(deps): bundle dagger module bumps for preview-env smoke test

### DIFF
--- a/dagger/go.mod
+++ b/dagger/go.mod
@@ -4,11 +4,11 @@ go 1.25.3
 
 require (
 	github.com/Khan/genqlient v0.8.1
-	github.com/dagger/otel-go v1.41.0
-	github.com/vektah/gqlparser/v2 v2.5.32
-	go.opentelemetry.io/otel v1.42.0
-	go.opentelemetry.io/otel/sdk v1.42.0
-	go.opentelemetry.io/otel/trace v1.42.0
+	github.com/dagger/otel-go v1.43.0
+	github.com/vektah/gqlparser/v2 v2.5.33
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 )
 
 require (
@@ -29,7 +29,7 @@ require (
 )
 
 require (
-	dagger.io/dagger v0.19.11
+	dagger.io/dagger v0.20.8
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -47,10 +47,10 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 
-replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
 
-replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.16.0
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0
 
-replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.16.0
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.19.0
 
-replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.16.0
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.19.0


### PR DESCRIPTION
## Summary

Bundles the four pending renovate PRs against `dagger/go.mod` into one branch so the `preview` label can drive a real preview-env smoke test on `homerun2-dev` — the first end-to-end exercise of the core-catcher AppSet (mirrors the omni-pitcher #116 rollout).

- `dagger.io/dagger`           v0.19.11 → v0.20.8 (#37)
- opentelemetry-go monorepo     v1.42.0 → v1.43.0 (#39)
  - otel/log replace directives  v0.16.0 → v0.19.0
- `github.com/dagger/otel-go`   v1.41.0 → v1.43.0 (#54)
- `github.com/vektah/gqlparser/v2` v2.5.32 → v2.5.33 (#55)

Closes #37
Closes #39
Closes #54
Closes #55

## Why `renovate/artifacts` is red (expected)

`dagger/main.go` imports `dagger/dagger/internal/dagger`, which is generated by `dagger develop` and `.gitignore`'d. Without that codegen present, `go mod tidy` (renovate's post-update step, or anyone's local run) strips every `require` from `dagger/go.mod`. Dagger's CI regenerates the internal package before build, which is why all the actual checks (`build / Build, Scan & Push Image`, `build-and-test`, `Lint-Repository`) are green on each of the four source PRs. Same expectation here.

## Test plan

- [ ] All real CI checks green (build-pr, build-and-test, lint-repo, push-kustomize, comment-preview-url)
- [ ] `preview` label triggers `homerun2-core-catcher-pr-preview` AppSet pickup within ~10m (`requeueAfterSeconds: 600`)
- [ ] Argo creates `homerun2-core-catcher-pr-<num>` Application + child Apps in `homerun2-dev`
- [ ] Kyverno policies materialize: quota, ExternalSecrets (`core-catcher-redis`, `omni-pitcher-token`, `omni-pitcher-redis`, `redis-stack-auth`), seed-data Job
- [ ] HTTPRoute resolves: `cc-pr-<num>.homerun2-dev.sthings-vsphere.labul.sva.de` returns the core-catcher dashboard
- [ ] Seed Job posts fixture events → dashboard non-empty on load (note known issue from #116: jq fix pending — last of 5 events may be dropped)
- [ ] PR close tears the namespace down (sweep + AppSet drop + finalizer prune)
- [ ] Close superseded renovate PRs #37 #39 #54 #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)