### PR TITLE
feat: ship HTTPRoute in the kustomize OCI base (Option B for argocd#116)

### DIFF
--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -6,3 +6,12 @@ config.redisStream: messages
 config.consumerGroup: homerun2-core-catcher
 config.redisPassword: changeme # pragma: allowlist secret
 config.catcherMode: web
+# HTTPRoute lives in the same kustomize apply as the Service so they land
+# atomically — avoids the Cilium gateway controller caching BackendNotFound
+# when the HTTPRoute is created before its Service (stuttgart-things/argocd#116).
+# Consumers without a Gateway API can drop the HTTPRoute via a kustomize delete
+# patch; the homerun2-install chart patches the parentRef + hostname per env.
+config.httpRouteEnabled: true
+config.httpRouteParentRefName: homerun2-dev-gateway
+config.httpRouteParentRefNamespace: default
+config.httpRouteHostname: homerun2-core-catcher.example.com


### PR DESCRIPTION
## Summary

Flip `config.httpRouteEnabled` to `true` in the default KCL deploy profile so the core-catcher kustomize OCI carries the HTTPRoute alongside the Service. The KCL (`kcl/httproute.k`) was already conditional on the flag — this just enables it with placeholder gateway + hostname defaults.

**Why** — stuttgart-things/argocd#116: the per-PR preview env races the Cilium gateway controller when the HTTPRoute is created by one ArgoCD Application before the Service is created by another. Cilium stamps `BackendNotFound` and never re-resolves. Shipping HTTPRoute + Service in the same kustomize apply eliminates the cross-Application race architecturally.

This is **Option B** from the issue, mirroring **stuttgart-things/homerun2-omni-pitcher#125** verbatim with core-catcher's name + a placeholder hostname (the install chart will patch parentRef + hostname per env).

## Diff

```diff
+# HTTPRoute lives in the same kustomize apply as the Service so they land
+# atomically — avoids the Cilium gateway controller caching BackendNotFound
+# when the HTTPRoute is created before its Service (stuttgart-things/argocd#116).
+# Consumers without a Gateway API can drop the HTTPRoute via a kustomize delete
+# patch; the homerun2-install chart patches the parentRef + hostname per env.
+config.httpRouteEnabled: true
+config.httpRouteParentRefName: homerun2-dev-gateway
+config.httpRouteParentRefNamespace: default
+config.httpRouteHostname: homerun2-core-catcher.example.com
```

## Local render verified

```sh
cd kcl
kcl run main.k \
  -D config.httpRouteEnabled=true \
  -D config.httpRouteParentRefName=homerun2-dev-gateway \
  -D config.httpRouteParentRefNamespace=default \
  -D config.httpRouteHostname=homerun2-core-catcher.example.com
```

emits an `HTTPRoute` (`gateway.networking.k8s.io/v1`) with:
- `parentRefs[0].name = homerun2-dev-gateway`, `namespace = default`
- `hostnames = [homerun2-core-catcher.example.com]`
- `backendRefs[0].name = homerun2-core-catcher`, `port = 80`

## ⚠️ Do NOT add `preview` label to this PR

This change is the **repo-side leg of a three-repo coordinated rollout**. Until the chart-side (step 2) lands, both this PR's inline HTTPRoute (from the new kustomize OCI) **and** the standalone `apps/homerun2/httproute` Application would create an `HTTPRoute/homerun2-core-catcher` in the same namespace — Argo sync conflict.

### Follow-up sequence (mirrors omni-pitcher rollout)

| Step | Repo | Mirror of |
|--|--|--|
| 1 | **this PR** | omni-pitcher #125 |
| 2 | `stuttgart-things/argocd` — chart-side `coreCatcher.inlineHttpRoute` opt-in flag + exclude core-catcher from standalone httproute when set | argocd#117 |
| 3 | `stuttgart-things/stuttgart-things` — set `coreCatcher.inlineHttpRoute: true` in `core-catcher-pr-preview-appset.yaml` | stuttgart-things#2194 |

Once all three merge, fresh core-catcher preview PRs land `homerun2-pr-<num>-core-catcher` Synced/Healthy on first reconcile — no more `kubectl annotate reconcile-bump=…` workaround.

## Test plan

- [x] Local KCL render confirms HTTPRoute manifest is emitted
- [ ] CI green (build-pr, build-and-test, lint, push-kustomize, comment)
- [ ] Steps 2 + 3 land in the other two repos
- [ ] Next core-catcher PR after steps 2 + 3 lands `HTTPRoute` at `ResolvedRefs: True` without manual reconcile-bump

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
