### PR TITLE
docs(cicd): list PR-preview workflows in the workflow table

### DIFF
--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -2,13 +2,28 @@
 
 ## GitHub Actions Workflows
 
+### Core
+
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
 | `build-test.yaml` | PR / push to main | Dagger lint + build + test |
-| `build-scan-image.yaml` | Push to main | ko build + Trivy scan |
+| `build-scan-image.yaml` | PR / push to main | ko build + Trivy scan; PR job tags `pr-<num>-<sha>` for preview envs, main job tags `:main` |
 | `release.yaml` | After image build / manual | Semantic release + stage image + push kustomize OCI |
 | `pages.yaml` | After release / manual | Deploy MkDocs to GitHub Pages |
 | `lint-repo.yaml` | PR / push to main | Repository linting |
+
+### PR-preview env
+
+These four together drive the per-PR ephemeral preview environment on `homerun2-dev` for PRs carrying the `preview` label.
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| `build-scan-image.yaml` (PR job) | PR opened/updated | ko image tagged `pr-<num>-<sha>` + `pr-<num>` consumed by the per-PR ArgoCD Application |
+| `push-kustomize-pr.yaml` | PR opened/updated | Kustomize OCI tagged `pr-<num>-<sha>` (renders `kcl/main.k` against `tests/kcl-deploy-profile.yaml`) |
+| `comment-preview-url.yaml` | PR opened/reopened | Sticky bot comment with the preview URL, namespace, and ArgoCD link |
+| `cleanup-pr-artifacts.yaml` | PR closed | Deletes both ghcr.io packages so version histories don't fill with PR debris |
+
+See [Preview Environments](preview-environments.md) for the full flow, AppSet anatomy, and troubleshooting.
 
 ## Dagger Functions
 


### PR DESCRIPTION
## Summary

Brings `docs/cicd.md`'s GitHub Actions workflow table up to date with the per-PR preview-env rollout from [stuttgart-things/homerun2-omni-pitcher#116](https://github.com/stuttgart-things/homerun2-omni-pitcher/issues/116) step 3. The four workflows that drive the preview env on `homerun2-dev` were missing from the doc.

Splits the table into **Core** and **PR-preview env** sections:

- `build-scan-image.yaml`'s PR job is now called out (tags `pr-<num>-<sha>` + `pr-<num>`)
- Adds `push-kustomize-pr.yaml`, `comment-preview-url.yaml`, `cleanup-pr-artifacts.yaml`
- Cross-links to `docs/preview-environments.md` (added in PR #64) for the full flow

Docs-only; no code changes.

## Test plan

- [x] Diff reads as a sensible split, both sections accurate against `.github/workflows/`
- [ ] mkdocs builds clean on merge (handled by `pages.yaml`)

## Note on the cross-link

The link to `preview-environments.md` resolves once **#64** merges (the page lives on that branch). If #64 is closed instead, the link will need a follow-up.

No `preview` label on this one — docs-only, no preview env needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
