### PR TITLE
fix(ci): publish main builds to ghcr.io as :main

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -30,4 +30,9 @@ jobs:
     with:
       runs-on: ubuntu-latest
       go-version: "1.26.6"
+      # Without these, call-ko-build falls back to its ttl.sh/latest defaults
+      # and main images never reach ghcr.io — which left :main frozen at
+      # v0.6.1 (2026-03-13) while the docs claimed otherwise (#85).
+      registry: ghcr.io
+      tags: main
     secrets: inherit # pragma: allowlist secret

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -7,7 +7,7 @@
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
 | `build-test.yaml` | PR / push to main | Dagger lint + build + test |
-| `build-scan-image.yaml` | PR / push to main | ko build + Trivy scan; PR job tags `pr-<num>-<sha>` for preview envs, main job tags `:main` |
+| `build-scan-image.yaml` | PR / push to main | ko build; both jobs push to `ghcr.io` — PR job tags `pr-<num>-<sha>` + `pr-<num>` for preview envs, main job tags `:main`. No image scan runs yet, despite the workflow name — see [#86](https://github.com/stuttgart-things/homerun2-core-catcher/issues/86) |
 | `release.yaml` | After image build / manual | Semantic release + stage image + push kustomize OCI |
 | `pages.yaml` | After release / manual | Deploy MkDocs to GitHub Pages |
 | `lint-repo.yaml` | PR / push to main | Repository linting |


### PR DESCRIPTION
Closes #85

## Problem

`build-main` passed no `registry` and no `tags`, so the reusable `call-ko-build.yaml` used its defaults — `ttl.sh` with tag `latest`. ttl.sh images expire after one hour, so **every main build since the workflow was introduced has been thrown away**, and the ghcr tag has stayed where it was:

```
$ gh api /orgs/stuttgart-things/packages/container/homerun2-core-catcher/versions
2026-03-13T15:17:02Z  v0.6.1,main
```

`tests/kcl-movie-scripts-profile.yaml` pins exactly that tag, so the movie-scripts cluster has been running March code.

## Change

```yaml
build-main:
  with:
    registry: ghcr.io
    tags: main
```

Plus a docs correction in `docs/cicd.md`: the `:main` half of that row becomes true with this change, the Trivy half does not — nothing scans our images today, so the row now says so and links #86.

## Verification after merge

- push to main → `ghcr.io/stuttgart-things/homerun2-core-catcher:main` gets a fresh digest dated today
- the run summary stops printing the "ttl.sh images expire after 1 hour" note

Same fix as stuttgart-things/homerun2-omni-pitcher#161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVBJo8GNa9mwWcu6cf5r7e