### PR TITLE
fix(release): pin a real image tag in the published kustomize base

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,5 +20,10 @@ jobs:
       push-kustomize: true
       kcl-source-dir: kcl
       kcl-profile-file: tests/kcl-deploy-profile.yaml
+      # Substitutes the released version into config.image so the published
+      # kustomize base pins a real tag. Without this the profile's placeholder
+      # ships verbatim, which meant every release shipped :latest — a tag last
+      # written on 2026-03-08 (#84).
+      kustomize-image-key: config.image
       kustomize-oci-repo: ghcr.io/stuttgart-things/homerun2-core-catcher-kustomize
     secrets: inherit # pragma: allowlist secret

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -10,7 +10,11 @@ schema CoreCatcher:
     namespace: str = "homerun2"
 
     # Image
-    image: str = "ghcr.io/stuttgart-things/homerun2-core-catcher:latest"
+    # Placeholder for local renders only — the Release workflow overrides this
+    # with the released version via kustomize-image-key. Points at :main rather
+    # than :latest because :latest is not maintained and still resolves to
+    # v0.2.0 from March.
+    image: str = "ghcr.io/stuttgart-things/homerun2-core-catcher:main"
     imagePullPolicy: str = "IfNotPresent"
 
     # Replicas and resources

--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -1,4 +1,4 @@
-config.image: ghcr.io/stuttgart-things/homerun2-core-catcher:latest
+config.image: ghcr.io/stuttgart-things/homerun2-core-catcher:main
 config.namespace: homerun2
 config.redisAddr: redis-stack.homerun2.svc.cluster.local
 config.redisPort: "6379"


### PR DESCRIPTION
Closes #84 · depends on #102 (#85) for `:main` to be a live tag

## Problem

`release.yaml` renders `kcl/main.k` against `tests/kcl-deploy-profile.yaml` and pushes the result as the kustomize OCI base — including the profile's placeholder image:

```yaml
config.image: ghcr.io/stuttgart-things/homerun2-core-catcher:latest
```

That tag was last written on **2026-03-08** and resolves to **v0.2.0**:

```
2026-03-08T20:18:41Z  v0.2.0,latest
2026-08-18T…          v0.13.4          <- today's release, :latest untouched
```

So every release since March has published a base that deploys March code.

## Change

- `release.yaml` — pass `kustomize-image-key: config.image`. The reusable workflow then substitutes `ghcr.io/<repo>:<version>` into that key, overriding the profile.
- `kcl/schema.k` + `tests/kcl-deploy-profile.yaml` — move the placeholder from `:latest` to `:main`, so local renders and any consumer that bypasses the substitution get a tag that tracks main (live once #102 merges) instead of a stale one that looks current.

## Verified locally

```
$ kcl run main.k -D config.image=… -D config.httpRouteEnabled=true …
ServiceAccount, ConfigMap, Secret, Deployment, Service, HTTPRoute
image: ghcr.io/stuttgart-things/homerun2-core-catcher:main
```

## After merge

Next release should publish a base pinning `ghcr.io/stuttgart-things/homerun2-core-catcher:v0.13.x` — worth checking the OCI artifact once.

Note for later: ghcr `:latest` still resolves to v0.2.0 and is now referenced by nothing in this repo. Either re-point it on release or delete it, so nobody pulls it by convention — happy to file that separately.

Same fix as stuttgart-things/homerun2-omni-pitcher#162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVBJo8GNa9mwWcu6cf5r7e