### PR TITLE
fix(release): re-point ghcr :latest at each release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,10 @@ jobs:
       runs-on: ubuntu-latest
       go-version: "1.26.6"
       stage-image: true
+      # Moves :latest onto every release. Without it the pipeline only ever
+      # writes the version tag, and :latest sat on v0.2.0 from March while
+      # releases reached v0.13.x (#104).
+      image-extra-tags: latest
       push-kustomize: true
       kcl-source-dir: kcl
       kcl-profile-file: tests/kcl-deploy-profile.yaml


### PR DESCRIPTION
Closes #104 · needs stuttgart-things/github-workflow-templates#146 (merged)

## Problem

`ghcr.io/stuttgart-things/homerun2-core-catcher:latest` resolves to **v0.2.0 from 2026-03-08**, because `call-go-release.yaml` pushed the staged image with the version tag only:

```sh
ko build --bare --tags="${VERSION}" …
```

#84 removed the immediate damage by stopping the published kustomize base from referencing `:latest`. The tag itself stayed wrong.

## Change

```yaml
with:
  stage-image: true
  image-extra-tags: latest
```

The template appends it to the version tag inside the same `ko build`, so both tags land on the same digest in one push — no separate re-tagging step that can drift or half-fail.

## Verification after merge

This commit is a `fix:`, so semantic-release cuts a version. Expected afterwards:

```
$ gh api /orgs/stuttgart-things/packages/container/homerun2-core-catcher/versions
<today>  vX.Y.Z,latest
```

## Not included

The kustomize OCI artifact keeps version tags only — consumers pin a version there deliberately (the homerun2 install chart does), so a moving kustomize tag would invite the opposite mistake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVBJo8GNa9mwWcu6cf5r7e