### PR TITLE
ci: run the Go test suite

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -30,6 +30,13 @@ jobs:
           call: lint --src . --progress plain
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
+      - name: Dagger go test
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          module: ./dagger
+          call: test --src . --progress plain
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
       - name: Dagger build-and-test
         uses: dagger/dagger-for-github@v8.4.1
         with:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -62,6 +62,15 @@ tasks:
 
   # === Build & Test ===
 
+  test:
+    desc: Run the Go test suite with Redis via Dagger
+    cmds:
+      - |
+        dagger call -m {{ .DAGGER_MODULE_DIR }} \
+        test \
+        --src "{{ .SOURCE_CODE_DIR }}" \
+        --progress plain
+
   build-test-binary:
     desc: Build and test binary with Redis via Dagger
     cmds:

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -26,6 +26,41 @@ func (m *Dagger) Lint(
 	})
 }
 
+// Test runs the Go test suite with a Redis service bound, so tests that talk
+// to Redis work the same way they do in the smoke test.
+//
+// It returns the test output and fails the call when the suite fails - the
+// point being that CI can go red. See issue #107.
+func (m *Dagger) Test(
+	ctx context.Context,
+	src *dagger.Directory,
+	// +optional
+	// +default="1.26.6"
+	goVersion string,
+	// +optional
+	// +default="./..."
+	testPath string,
+) (string, error) {
+	redisService := dag.Homerun().RedisService(dagger.HomerunRedisServiceOpts{
+		Version:  "7.2.0-v18",
+		Password: "",
+	})
+
+	return dag.Container().
+		From("golang:"+goVersion).
+		WithDirectory("/src", src).
+		WithWorkdir("/src").
+		WithMountedCache("/go/pkg/mod", dag.CacheVolume("gomod")).
+		WithMountedCache("/root/.cache/go-build", dag.CacheVolume("gobuild")).
+		WithServiceBinding("redis", redisService).
+		WithEnvVariable("REDIS_ADDR", "redis").
+		WithEnvVariable("REDIS_PORT", "6379").
+		WithEnvVariable("REDIS_STREAM", "messages").
+		WithEnvVariable("LOG_FORMAT", "text").
+		WithExec([]string{"go", "test", "-v", "-cover", testPath}).
+		Stdout(ctx)
+}
+
 // Build compiles the Go binary
 func (m *Dagger) Build(
 	ctx context.Context,
@@ -111,9 +146,6 @@ func (m *Dagger) BuildAndTestBinary(
 	// +optional
 	// +default="."
 	packageName string,
-	// +optional
-	// +default="./..."
-	testPath string,
 ) (*dagger.File, error) {
 
 	binDir := dag.Go().BuildBinary(


### PR DESCRIPTION
Closes #107.

## Problem

14 Testdateien, **keine davon lief in CI**. `go test` kam weder in `.github/workflows/` noch in `dagger/main.go` vor. Pipeline war: Lint → `build-and-test-binary` (Binary bauen + curl/redis-cli-Smoke-Skript).

`BuildAndTestBinary` behauptete das Gegenteil — `dagger/main.go:116`:

```go
	// +optional
	// +default="./..."
	testPath string,
```

Der Parameter kam im ganzen File genau einmal vor: in seiner eigenen Deklaration. Funktionsname und Signatur versprachen einen Testlauf, den es nicht gab.

## Lösung

Neue `Test`-Funktion im Dagger-Modul: Go-Container, Redis als Service gebunden (dieselben `REDIS_*`-Variablen wie im Smoke-Test), `go test -v -cover`. Als eigener Schritt in `build-test.yaml` vor `build-and-test-binary`, plus `task test` im Taskfile.

`testPath` wandert dorthin, wo er benutzt wird, und verschwindet aus `BuildAndTestBinary`.

## Verifiziert

```
dagger call -m dagger test --src .
  → alle Pakete grün, coverage: 90.0% of statements (internal/store)
```

Und der Gegenbeweis — mit einem absichtlich fehlschlagenden Test:

```
dagger call -m dagger test --src .   → exit 1
```

## Nachtrag zum Issue

Die Bemerkung zu `homerun2-scout` in #107 stimmt nicht: das Verzeichnis liegt bei mir nur lokal untracked herum, in `origin/main` gibt es kein `homerun2-scout`. Hier ist also nichts zusätzlich zu verdrahten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GN8vHssMh4ynNwxRMjupVH